### PR TITLE
Fix Rust in kernel

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -74,6 +74,9 @@ let
       };
 
       kernelPatches = [
+        { name = "rust-bindgen-version";
+          patch = ./rust-bindgen-version.patch;
+        }
       ] ++ lib.optionals _4KBuild [
         # thanks to Sven Peter
         # https://lore.kernel.org/linux-iommu/20211019163737.46269-1-sven@svenpeter.dev/

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -124,16 +124,14 @@ let
         rustPlatform.rust.rustc
         removeReferencesTo
       ];
+      # HACK: references shouldn't have been there in the first place
+      postFixup = (old.postFixup or "") + ''
+        remove-references-to -t $out $dev/lib/modules/${old.version}/build/vmlinux
+        remove-references-to -t $dev $out/Image
+      '';
       RUST_LIB_SRC = rustPlatform.rustLibSrc;
     } else {});
 
-  linux-asahi = (callPackage linux-asahi-pkg { })
-  # HACK: references shouldn't have been there in the first place
-  .overrideAttrs (_: prev: prev // {
-      postFixup = ''
-        remove-references-to -t $out $dev/lib/modules/${prev.version}/build/vmlinux
-        remove-references-to -t $dev $out/Image
-      '';
-  });
+  linux-asahi = (callPackage linux-asahi-pkg { });
 in lib.recurseIntoAttrs (linuxPackagesFor linux-asahi)
 

--- a/apple-silicon-support/packages/linux-asahi/rust-bindgen-version.patch
+++ b/apple-silicon-support/packages/linux-asahi/rust-bindgen-version.patch
@@ -1,0 +1,14 @@
+diff --git a/scripts/rust_is_available.sh b/scripts/rust_is_available.sh
+index aebbf1913..b7b0a4abc 100755
+--- a/scripts/rust_is_available.sh
++++ b/scripts/rust_is_available.sh
+@@ -102,8 +102,7 @@ fi
+ # Check that the `libclang` used by the Rust bindings generator is suitable.
+ bindgen_libclang_version=$( \
+ 	LC_ALL=C "$BINDGEN" $(dirname $0)/rust_is_available_bindgen_libclang.h 2>&1 >/dev/null \
+-		| grep -F 'clang version ' \
+-		| grep -oE '[0-9]+\.[0-9]+\.[0-9]+' \
++		| grep -oP 'clang version \K[0-9]+\.[0-9]+\.[0-9]+' \
+ 		| head -n 1 \
+ )
+ bindgen_libclang_min_version=$($min_tool_version llvm)


### PR DESCRIPTION
Fixes #63 

Depends on #68 

This is certainly not how it _should_ be fixed. The bindgen version detection should ideally be fixed upstream, and the cross-references between `dev` and `out` should be properly addressed. Therefore, I'm not sure if you'll want to merge this. However, I wanted to submit anyway it so that other people could use it in the meantime