### PR TITLE
Move away from wpa_supplicant to iwd

### DIFF
--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -278,7 +278,21 @@ Some keyboard layouts are not detected correctly. On some devices, the \` key is
 
 Once you are happy with your initial configuration, you may install the system. This will have to download a large amount of data.
 
-You can configure wireless networking in the installer using `wpa_supplicant` by following [the minimal installer directions](https://nixos.org/manual/nixos/stable/index.html#sec-installation-booting-networking) in the NixOS manual.
+We use iwd instead of wpa_supplicant because the latter [does not support WPA3 on broadcom chips](https://www.reddit.com/r/AsahiLinux/comments/12igyoa/comment/jftvl3c) (which are installed on macs) and in general iwd is more modern, easy to use and maintained then wpa_supplicant.<br>
+You can configure WiFi in the installer using `iwctl`:
+```
+nixos# iwctl
+NetworkConfigurationEnabled: enabled
+StateDirectory: /var/lib/iwd
+Version: 2.4
+[iwd]# station wlan0 connect <SSID>
+Type the network passphrase for <SSID> psk.
+Passphrase: <your passphrase>
+[iwd]# station wlan0 show
+[...]
+[iwd] exit
+```
+
 
 Once the network is set up, ensure the time is set correctly, then install the system. You will be asked to set a root password as the final step:
 ```

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -80,15 +80,20 @@
   documentation.nixos.enable = lib.mkOverride 49 false;
   system.extraDependencies = lib.mkForce [ ];
 
-  networking.wireless.enable = true;
-  networking.wireless.userControlled.enable = true;
-  systemd.services.wpa_supplicant.wantedBy = lib.mkOverride 50 [];
+  # Disable wpa_supplicant because it can't use WPA3-SAE on broadcom chips that are used on macs and it is harder to use and less mainained than iwd in general
+  networking.wireless.enable = false;
+  # Enable iwd
+  networking.wireless.iwd = {
+    enable = true;
+    settings.General.EnableNetworkConfiguration = true;
+  };
+  
 
   nixpkgs.overlays = [
     (final: prev: {
       # disabling pcsclite avoids the need to cross-compile gobject
       # introspection stuff which works now but is slow and unnecessary
-      wpa_supplicant = prev.wpa_supplicant.override {
+      iwd = prev.iwd.override {
         withPcsclite = false;
       };
       libfido2 = prev.libfido2.override {


### PR DESCRIPTION
It is better to use iwd instead of wpa_supplicant because the latter [does not support WPA3 on broadcom chips](https://www.reddit.com/r/AsahiLinux/comments/12igyoa/comment/jftvl3c) (which are installed on macs) and in general iwd is more modern, easy to use and maintained then wpa_supplicant.<br>
This PR is a draft because it must be merged at the same time as new release image is uploaded because otherwise it may confuse people who expect iwd to be availible in old installation ISO with wpa_supplicant.