### PR TITLE
Remove the Rust 1.70 patch

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -116,15 +116,6 @@ let
           patch = ./rust_1_67_0.patch;
           reverse = true;
         }
-      ] ++ lib.optionals (rustOlder "1.70.0") [
-        { name = "rust-1.70.0";
-          patch = pkgs.fetchpatch {
-            name = "rust-1.70.patch";
-            url = "https://github.com/AsahiLinux/linux/commit/496a1b061691f01602aa63d2a8027cf3020d4bb8.diff";
-            hash = "sha256-RxOzCE22+yfZ3r/1sjbP8Cp+rRa56SJjHjwjTJxfIUI=";
-          };
-          reverse = true;
-        }
       ] ++ _kernelPatches;
 
       inherit configfile config;


### PR DESCRIPTION
I saw this was changed in the commit, so I thought it might be a mistake. The kernel rejects the patch on Rust 1.69 (latest nixos stable as of today) otherwise.

Build logs
```
applying patch /nix/store/1an7d69g4ig8dnnjxd1488j4l8c6ykn9-rust-1.70.patch
patching file rust/alloc/lib.rs
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file rust/alloc/lib.rs.rej
patching file rust/alloc/vec/into_iter.rs
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
5 out of 5 hunks ignored -- saving rejects to file rust/alloc/vec/into_iter.rs.rej
patching file scripts/Makefile.build
Reversed (or previously applied) patch detected!  Assume -R? [n] 
Apply anyway? [n] 
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file scripts/Makefile.build.rej
```