### PR TITLE
add patch for rust 1.71

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -116,6 +116,10 @@ let
           patch = ./rust_1_67_0.patch;
           reverse = true;
         }
+      ] ++ lib.optionals (rustAtLeast "1.71.0") [
+        { name = "rust-1.71.0";
+          patch = ./rust_1_71_0.patch;
+        }
       ] ++ _kernelPatches;
 
       inherit configfile config;

--- a/apple-silicon-support/packages/linux-asahi/rust_1_71_0.patch
+++ b/apple-silicon-support/packages/linux-asahi/rust_1_71_0.patch
@@ -1,0 +1,384 @@
+diff --git a/rust/Makefile b/rust/Makefile
+index e27f5d90843688..ce472b2113c851 100644
+--- a/rust/Makefile
++++ b/rust/Makefile
+@@ -396,8 +396,8 @@ rust-analyzer:
+ 		$(RUST_LIB_SRC) > $(objtree)/rust-project.json
+ 
+ redirect-intrinsics = \
+-	__eqsf2 __gesf2 __lesf2 __nesf2 __unordsf2 \
+-	__unorddf2 \
++	__addsf3 __eqsf2 __gesf2 __lesf2 __ltsf2 __mulsf3 __nesf2 __unordsf2 \
++	__adddf3 __ledf2 __ltdf2 __muldf3 __unorddf2 \
+ 	__muloti4 __multi3 \
+ 	__udivmodti4 __udivti3 __umodti3 \
+ 	__aeabi_fcmpeq __aeabi_fcmpun __aeabi_dcmpun __aeabi_uldivmod
+diff --git a/rust/compiler_builtins.rs b/rust/compiler_builtins.rs
+index 565a583db7ad75..fd2fcaeca0b43d 100644
+--- a/rust/compiler_builtins.rs
++++ b/rust/compiler_builtins.rs
+@@ -37,14 +37,21 @@ macro_rules! define_panicking_intrinsics(
+ );
+ 
+ define_panicking_intrinsics!("`f32` should not be used", {
++    __addsf3,
+     __eqsf2,
+     __gesf2,
+     __lesf2,
++    __ltsf2,
++    __mulsf3,
+     __nesf2,
+     __unordsf2,
+ });
+ 
+ define_panicking_intrinsics!("`f64` should not be used", {
++    __adddf3,
++    __ledf2,
++    __ltdf2,
++    __muldf3,
+     __unorddf2,
+ });
+ 
+diff --git a/rust/alloc/alloc.rs b/rust/alloc/alloc.rs
+index 0142178370e9..15596f01df25 100644
+--- a/rust/alloc/alloc.rs
++++ b/rust/alloc/alloc.rs
+@@ -337,16 +337,12 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
+ 
+ #[cfg_attr(not(test), lang = "box_free")]
+ #[inline]
+-#[rustc_const_unstable(feature = "const_box", issue = "92521")]
+ // This signature has to be the same as `Box`, otherwise an ICE will happen.
+ // When an additional parameter to `Box` is added (like `A: Allocator`), this has to be added here as
+ // well.
+ // For example if `Box` is changed to  `struct Box<T: ?Sized, A: Allocator>(Unique<T>, A)`,
+ // this function has to be changed to `fn box_free<T: ?Sized, A: Allocator>(Unique<T>, A)` as well.
+-pub(crate) const unsafe fn box_free<T: ?Sized, A: ~const Allocator + ~const Destruct>(
+-    ptr: Unique<T>,
+-    alloc: A,
+-) {
++pub(crate) unsafe fn box_free<T: ?Sized, A: Allocator>(ptr: Unique<T>, alloc: A) {
+     unsafe {
+         let size = size_of_val(ptr.as_ref());
+         let align = min_align_of_val(ptr.as_ref());
+diff --git a/rust/alloc/boxed.rs b/rust/alloc/boxed.rs
+index d4a03edd7d89..5c1bd717f494 100644
+--- a/rust/alloc/boxed.rs
++++ b/rust/alloc/boxed.rs
+@@ -380,12 +380,11 @@ impl<T, A: Allocator> Box<T, A> {
+     /// ```
+     #[cfg(not(no_global_oom_handling))]
+     #[unstable(feature = "allocator_api", issue = "32838")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[must_use]
+     #[inline]
+-    pub const fn new_in(x: T, alloc: A) -> Self
++    pub fn new_in(x: T, alloc: A) -> Self
+     where
+-        A: ~const Allocator + ~const Destruct,
++        A: Allocator
+     {
+         let mut boxed = Self::new_uninit_in(alloc);
+         unsafe {
+@@ -410,12 +409,10 @@ impl<T, A: Allocator> Box<T, A> {
+     /// # Ok::<(), std::alloc::AllocError>(())
+     /// ```
+     #[unstable(feature = "allocator_api", issue = "32838")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+-    pub const fn try_new_in(x: T, alloc: A) -> Result<Self, AllocError>
++    pub fn try_new_in(x: T, alloc: A) -> Result<Self, AllocError>
+     where
+-        T: ~const Destruct,
+-        A: ~const Allocator + ~const Destruct,
++        A: Allocator
+     {
+         let mut boxed = Self::try_new_uninit_in(alloc)?;
+         unsafe {
+@@ -445,13 +442,12 @@ impl<T, A: Allocator> Box<T, A> {
+     /// assert_eq!(*five, 5)
+     /// ```
+     #[unstable(feature = "allocator_api", issue = "32838")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[cfg(not(no_global_oom_handling))]
+     #[must_use]
+     // #[unstable(feature = "new_uninit", issue = "63291")]
+-    pub const fn new_uninit_in(alloc: A) -> Box<mem::MaybeUninit<T>, A>
++    pub fn new_uninit_in(alloc: A) -> Box<mem::MaybeUninit<T>, A>
+     where
+-        A: ~const Allocator + ~const Destruct,
++        A: Allocator
+     {
+         let layout = Layout::new::<mem::MaybeUninit<T>>();
+         // NOTE: Prefer match over unwrap_or_else since closure sometimes not inlineable.
+@@ -486,10 +482,9 @@ impl<T, A: Allocator> Box<T, A> {
+     /// ```
+     #[unstable(feature = "allocator_api", issue = "32838")]
+     // #[unstable(feature = "new_uninit", issue = "63291")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+-    pub const fn try_new_uninit_in(alloc: A) -> Result<Box<mem::MaybeUninit<T>, A>, AllocError>
++    pub fn try_new_uninit_in(alloc: A) -> Result<Box<mem::MaybeUninit<T>, A>, AllocError>
+     where
+-        A: ~const Allocator + ~const Destruct,
++        A: Allocator
+     {
+         let layout = Layout::new::<mem::MaybeUninit<T>>();
+         let ptr = alloc.allocate(layout)?.cast();
+@@ -517,13 +512,12 @@ impl<T, A: Allocator> Box<T, A> {
+     ///
+     /// [zeroed]: mem::MaybeUninit::zeroed
+     #[unstable(feature = "allocator_api", issue = "32838")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[cfg(not(no_global_oom_handling))]
+     // #[unstable(feature = "new_uninit", issue = "63291")]
+     #[must_use]
+-    pub const fn new_zeroed_in(alloc: A) -> Box<mem::MaybeUninit<T>, A>
++    pub fn new_zeroed_in(alloc: A) -> Box<mem::MaybeUninit<T>, A>
+     where
+-        A: ~const Allocator + ~const Destruct,
++        A: Allocator
+     {
+         let layout = Layout::new::<mem::MaybeUninit<T>>();
+         // NOTE: Prefer match over unwrap_or_else since closure sometimes not inlineable.
+@@ -558,10 +552,9 @@ impl<T, A: Allocator> Box<T, A> {
+     /// [zeroed]: mem::MaybeUninit::zeroed
+     #[unstable(feature = "allocator_api", issue = "32838")]
+     // #[unstable(feature = "new_uninit", issue = "63291")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+-    pub const fn try_new_zeroed_in(alloc: A) -> Result<Box<mem::MaybeUninit<T>, A>, AllocError>
++    pub fn try_new_zeroed_in(alloc: A) -> Result<Box<mem::MaybeUninit<T>, A>, AllocError>
+     where
+-        A: ~const Allocator + ~const Destruct,
++        A: Allocator
+     {
+         let layout = Layout::new::<mem::MaybeUninit<T>>();
+         let ptr = alloc.allocate_zeroed(layout)?.cast();
+@@ -577,12 +570,11 @@ impl<T, A: Allocator> Box<T, A> {
+     /// construct a (pinned) `Box` in a different way than with [`Box::new_in`].
+     #[cfg(not(no_global_oom_handling))]
+     #[unstable(feature = "allocator_api", issue = "32838")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[must_use]
+     #[inline(always)]
+-    pub const fn pin_in(x: T, alloc: A) -> Pin<Self>
++    pub fn pin_in(x: T, alloc: A) -> Pin<Self>
+     where
+-        A: 'static + ~const Allocator + ~const Destruct,
++        A: 'static + Allocator
+     {
+         Self::into_pin(Self::new_in(x, alloc))
+     }
+@@ -591,8 +583,7 @@ impl<T, A: Allocator> Box<T, A> {
+     ///
+     /// This conversion does not allocate on the heap and happens in place.
+     #[unstable(feature = "box_into_boxed_slice", issue = "71582")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+-    pub const fn into_boxed_slice(boxed: Self) -> Box<[T], A> {
++    pub fn into_boxed_slice(boxed: Self) -> Box<[T], A> {
+         let (raw, alloc) = Box::into_raw_with_allocator(boxed);
+         unsafe { Box::from_raw_in(raw as *mut [T; 1], alloc) }
+     }
+@@ -609,12 +600,8 @@ impl<T, A: Allocator> Box<T, A> {
+     /// assert_eq!(Box::into_inner(c), 5);
+     /// ```
+     #[unstable(feature = "box_into_inner", issue = "80437")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+-    pub const fn into_inner(boxed: Self) -> T
+-    where
+-        Self: ~const Destruct,
+-    {
++    pub fn into_inner(boxed: Self) -> T {
+         *boxed
+     }
+ }
+@@ -828,9 +815,8 @@ impl<T, A: Allocator> Box<mem::MaybeUninit<T>, A> {
+     /// assert_eq!(*five, 5)
+     /// ```
+     #[unstable(feature = "new_uninit", issue = "63291")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+-    pub const unsafe fn assume_init(self) -> Box<T, A> {
++    pub unsafe fn assume_init(self) -> Box<T, A> {
+         let (raw, alloc) = Box::into_raw_with_allocator(self);
+         unsafe { Box::from_raw_in(raw as *mut T, alloc) }
+     }
+@@ -863,9 +849,8 @@ impl<T, A: Allocator> Box<mem::MaybeUninit<T>, A> {
+     /// }
+     /// ```
+     #[unstable(feature = "new_uninit", issue = "63291")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+-    pub const fn write(mut boxed: Self, value: T) -> Box<T, A> {
++    pub fn write(mut boxed: Self, value: T) -> Box<T, A> {
+         unsafe {
+             (*boxed).write(value);
+             boxed.assume_init()
+@@ -1109,9 +1094,8 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
+     ///
+     /// [memory layout]: self#memory-layout
+     #[unstable(feature = "allocator_api", issue = "32838")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+-    pub const fn into_raw_with_allocator(b: Self) -> (*mut T, A) {
++    pub fn into_raw_with_allocator(b: Self) -> (*mut T, A) {
+         let (leaked, alloc) = Box::into_unique(b);
+         (leaked.as_ptr(), alloc)
+     }
+@@ -1121,10 +1105,9 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
+         issue = "none",
+         reason = "use `Box::leak(b).into()` or `Unique::from(Box::leak(b))` instead"
+     )]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+     #[doc(hidden)]
+-    pub const fn into_unique(b: Self) -> (Unique<T>, A) {
++    pub fn into_unique(b: Self) -> (Unique<T>, A) {
+         // Box is recognized as a "unique pointer" by Stacked Borrows, but internally it is a
+         // raw pointer for the type system. Turning it directly into a raw pointer would not be
+         // recognized as "releasing" the unique pointer to permit aliased raw accesses,
+@@ -1140,9 +1123,8 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
+     /// to call it as `Box::allocator(&b)` instead of `b.allocator()`. This
+     /// is so that there is no conflict with a method on the inner type.
+     #[unstable(feature = "allocator_api", issue = "32838")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+-    pub const fn allocator(b: &Self) -> &A {
++    pub fn allocator(b: &Self) -> &A {
+         &b.1
+     }
+ 
+@@ -1182,9 +1164,8 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
+     /// assert_eq!(*static_ref, [4, 2, 3]);
+     /// ```
+     #[stable(feature = "box_leak", since = "1.26.0")]
+-    #[rustc_const_unstable(feature = "const_box", issue = "92521")]
+     #[inline]
+-    pub const fn leak<'a>(b: Self) -> &'a mut T
++    pub fn leak<'a>(b: Self) -> &'a mut T
+     where
+         A: 'a,
+     {
+@@ -1460,8 +1441,7 @@ impl<T> From<T> for Box<T> {
+ }
+ 
+ #[stable(feature = "pin", since = "1.33.0")]
+-#[rustc_const_unstable(feature = "const_box", issue = "92521")]
+-impl<T: ?Sized, A: Allocator> const From<Box<T, A>> for Pin<Box<T, A>>
++impl<T: ?Sized, A: Allocator> From<Box<T, A>> for Pin<Box<T, A>>
+ where
+     A: 'static,
+ {
+@@ -1898,8 +1878,7 @@ impl<T: ?Sized, A: Allocator> fmt::Pointer for Box<T, A> {
+ }
+ 
+ #[stable(feature = "rust1", since = "1.0.0")]
+-#[rustc_const_unstable(feature = "const_box", issue = "92521")]
+-impl<T: ?Sized, A: Allocator> const Deref for Box<T, A> {
++impl<T: ?Sized, A: Allocator> Deref for Box<T, A> {
+     type Target = T;
+ 
+     fn deref(&self) -> &T {
+@@ -1908,8 +1887,7 @@ impl<T: ?Sized, A: Allocator> const Deref for Box<T, A> {
+ }
+ 
+ #[stable(feature = "rust1", since = "1.0.0")]
+-#[rustc_const_unstable(feature = "const_box", issue = "92521")]
+-impl<T: ?Sized, A: Allocator> const DerefMut for Box<T, A> {
++impl<T: ?Sized, A: Allocator> DerefMut for Box<T, A> {
+     fn deref_mut(&mut self) -> &mut T {
+         &mut **self
+     }
+diff --git a/rust/alloc/lib.rs b/rust/alloc/lib.rs
+index 98b6dae4ec6c..d06023a167f2 100644
+--- a/rust/alloc/lib.rs
++++ b/rust/alloc/lib.rs
+@@ -103,7 +103,6 @@
+ #![feature(const_box)]
+ #![cfg_attr(not(no_global_oom_handling), feature(const_btree_len))]
+ #![cfg_attr(not(no_borrow), feature(const_cow_is_borrowed))]
+-#![feature(const_convert)]
+ #![feature(const_size_of_val)]
+ #![feature(const_align_of_val)]
+ #![feature(const_ptr_read)]
+@@ -164,7 +163,6 @@
+ #![feature(allow_internal_unstable)]
+ #![feature(associated_type_bounds)]
+ #![feature(cfg_sanitize)]
+-#![feature(const_deref)]
+ #![feature(const_mut_refs)]
+ #![feature(const_ptr_write)]
+ #![feature(const_precise_live_drops)]
+diff --git a/rust/alloc/vec/mod.rs b/rust/alloc/vec/mod.rs
+index 3308724352cc..2ad2c11ec2af 100644
+--- a/rust/alloc/vec/mod.rs
++++ b/rust/alloc/vec/mod.rs
+@@ -3300,8 +3300,7 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {
+ }
+ 
+ #[stable(feature = "rust1", since = "1.0.0")]
+-#[rustc_const_unstable(feature = "const_default_impls", issue = "87864")]
+-impl<T> const Default for Vec<T> {
++impl<T> Default for Vec<T> {
+     /// Creates an empty `Vec<T>`.
+     ///
+     /// The vector will not allocate until elements are pushed onto it.
+diff --git a/rust/kernel/allocator.rs b/rust/kernel/allocator.rs
+index 397a3dd57a9b..cfb406e2a710 100644
+--- a/rust/kernel/allocator.rs
++++ b/rust/kernel/allocator.rs
+@@ -26,39 +26,6 @@ unsafe impl GlobalAlloc for KernelAllocator {
+ #[global_allocator]
+ static ALLOCATOR: KernelAllocator = KernelAllocator;
+ 
+-// `rustc` only generates these for some crate types. Even then, we would need
+-// to extract the object file that has them from the archive. For the moment,
+-// let's generate them ourselves instead.
+-//
+-// Note that `#[no_mangle]` implies exported too, nowadays.
++// See <https://github.com/rust-lang/rust/pull/86844>.
+ #[no_mangle]
+-fn __rust_alloc(size: usize, _align: usize) -> *mut u8 {
+-    unsafe { bindings::krealloc(core::ptr::null(), size, bindings::GFP_KERNEL) as *mut u8 }
+-}
+-
+-#[no_mangle]
+-fn __rust_dealloc(ptr: *mut u8, _size: usize, _align: usize) {
+-    unsafe { bindings::kfree(ptr as *const core::ffi::c_void) };
+-}
+-
+-#[no_mangle]
+-fn __rust_realloc(ptr: *mut u8, _old_size: usize, _align: usize, new_size: usize) -> *mut u8 {
+-    unsafe {
+-        bindings::krealloc(
+-            ptr as *const core::ffi::c_void,
+-            new_size,
+-            bindings::GFP_KERNEL,
+-        ) as *mut u8
+-    }
+-}
+-
+-#[no_mangle]
+-fn __rust_alloc_zeroed(size: usize, _align: usize) -> *mut u8 {
+-    unsafe {
+-        bindings::krealloc(
+-            core::ptr::null(),
+-            size,
+-            bindings::GFP_KERNEL | bindings::__GFP_ZERO,
+-        ) as *mut u8
+-    }
+-}
++static __rust_no_alloc_shim_is_unstable: u8 = 0;
+diff --git a/rust/kernel/driver.rs b/rust/kernel/driver.rs
+index aa1441ae809b..e59f163d8ff3 100644
+--- a/rust/kernel/driver.rs
++++ b/rust/kernel/driver.rs
+@@ -221,7 +221,7 @@ pub struct IdTable<'a, T: RawDeviceId, U> {
+     _p: PhantomData<&'a U>,
+ }
+ 
+-impl<T: RawDeviceId, U> const AsRef<T::RawType> for IdTable<'_, T, U> {
++impl<T: RawDeviceId, U> AsRef<T::RawType> for IdTable<'_, T, U> {
+     fn as_ref(&self) -> &T::RawType {
+         self.first
+     }


### PR DESCRIPTION
Rust 1.71 is currently in staging-next.
I went through the errors and copied together the resolutions from https://github.com/Rust-for-Linux/linux/commit/327cfb66df6947db1618ec0dd339648b0db258e7 and https://github.com/Rust-for-Linux/linux/commit/6abe8c9688d6033f1d5cde1c0468e363602a7a1e