### PR TITLE
m1n1: 1.2.9 -> 1.3.3

### DIFF
--- a/apple-silicon-support/packages/m1n1/default.nix
+++ b/apple-silicon-support/packages/m1n1/default.nix
@@ -25,14 +25,14 @@ let
   });
 in stdenv.mkDerivation rec {
   pname = "m1n1";
-  version = "1.2.9";
+  version = "1.3.3";
 
   src = fetchFromGitHub {
     # tracking: https://github.com/AsahiLinux/PKGBUILDs/blob/main/m1n1/PKGBUILD
     owner = "AsahiLinux";
     repo = "m1n1";
     rev = "v${version}";
-    hash = "sha256-71fopEJ28LdymTmavBPtshIn87jvaVfRyeU1vKWADTc=";
+    hash = "sha256-kqXnvoTFE42DbGSTPZcWM8J/APG8th8QM93IwEnlmjw=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
This fixes brightness control on a M1 MacBook Air and possibly other devices.

Based on https://github.com/AsahiLinux/PKGBUILDs/commit/f96d51311473b2e6073fbc003d0838f299b1ec6b