### PR TITLE
alsa-ucm-conf-asahi: Add support for audio confs

### DIFF
--- a/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
+++ b/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, fetchFromGitHub
+, alsa-ucm-conf }:
+
+(alsa-ucm-conf.overrideAttrs (oldAttrs: rec {
+  version = "3";
+
+  src_asahi = fetchFromGitHub {
+    # tracking: https://github.com/AsahiLinux/PKGBUILDs/blob/main/alsa-ucm-conf-asahi/PKGBUILD
+    owner = "AsahiLinux";
+    repo = "alsa-ucm-conf-asahi";
+    rev = "v${version}";
+    hash = "sha256-TCCT0AJx0SdnTzzBaV94zuD2hrPqvk+9vTTuEQmpJjc=";
+  };
+  
+  postInstall = oldAttrs.postInstall or "" + ''
+    cp -r ${src_asahi}/ucm2 $out/share/alsa
+  '';
+}))

--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -4,5 +4,5 @@ final: prev: {
   uboot-asahi = final.callPackage ./uboot-asahi { };
   asahi-fwextract = final.callPackage ./asahi-fwextract { };
   mesa-asahi-edge = final.callPackage ./mesa-asahi-edge { inherit (prev) mesa; };
-  # TODO: package alsa-ucm-conf-asahi for headphone jack support
+  alsa-ucm-conf-asahi = final.callPackage ./alsa-ucm-conf-asahi { inherit (prev) alsa-ucm-conf; };
 }


### PR DESCRIPTION
This adds the package so that headphones volume work by overriding the upstream alsa-ucm-conf and copying the extra asahi ucm2 confs into destination folder

Not entirely sure how package should be added for default installation in modules