### PR TITLE
rust 1.73.0 patch

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -104,6 +104,10 @@ let
         { name = "rust-bindgen-version";
           patch = ./rust-bindgen-version.patch;
         }
+      ] ++ lib.optionals (rustAtLeast "1.73.0") [
+        { name = "rustc-1.73.0";
+          patch = ./rustc-1.73.0-fix.patch;
+        }
       ] ++ lib.optionals _4KBuild [
         # thanks to Sven Peter
         # https://lore.kernel.org/linux-iommu/20211019163737.46269-1-sven@svenpeter.dev/

--- a/apple-silicon-support/packages/linux-asahi/rustc-1.73.0-fix.patch
+++ b/apple-silicon-support/packages/linux-asahi/rustc-1.73.0-fix.patch
@@ -1,0 +1,232 @@
+diff --git a/rust/alloc/lib.rs b/rust/alloc/lib.rs
+index 49d643c3af6a..9107881810e4 100644
+--- a/rust/alloc/lib.rs
++++ b/rust/alloc/lib.rs
+@@ -138,7 +138,6 @@
+ #![feature(nonnull_slice_from_raw_parts)]
+ #![feature(pattern)]
+ #![feature(pointer_byte_offsets)]
+-#![feature(provide_any)]
+ #![feature(ptr_internals)]
+ #![feature(ptr_metadata)]
+ #![feature(ptr_sub_ptr)]
+diff --git a/rust/kernel/driver.rs b/rust/kernel/driver.rs
+index e59f163d8ff3..35f27ba8894e 100644
+--- a/rust/kernel/driver.rs
++++ b/rust/kernel/driver.rs
+@@ -108,68 +108,35 @@ fn drop(&mut self) {
+     }
+ }
+ 
+-/// Conversion from a device id to a raw device id.
+-///
+-/// This is meant to be implemented by buses/subsystems so that they can use [`IdTable`] to
+-/// guarantee (at compile-time) zero-termination of device id tables provided by drivers.
+-///
+-/// # Safety
+-///
+-/// Implementers must ensure that:
+-///   - [`RawDeviceId::ZERO`] is actually a zeroed-out version of the raw device id.
+-///   - [`RawDeviceId::to_rawid`] stores `offset` in the context/data field of the raw device id so
+-///     that buses can recover the pointer to the data.
+-#[const_trait]
+-pub unsafe trait RawDeviceId {
+-    /// The raw type that holds the device id.
+-    ///
+-    /// Id tables created from [`Self`] are going to hold this type in its zero-terminated array.
+-    type RawType: Copy;
+-
+-    /// A zeroed-out representation of the raw device id.
+-    ///
+-    /// Id tables created from [`Self`] use [`Self::ZERO`] as the sentinel to indicate the end of
+-    /// the table.
+-    const ZERO: Self::RawType;
+-
+-    /// Converts an id into a raw id.
+-    ///
+-    /// `offset` is the offset from the memory location where the raw device id is stored to the
+-    /// location where its associated context information is stored. Implementations must store
+-    /// this in the appropriate context/data field of the raw type.
+-    fn to_rawid(&self, offset: isize) -> Self::RawType;
+-}
+ 
+ /// A zero-terminated device id array.
+ #[derive(Copy, Clone)]
+ #[repr(C)]
+-pub struct IdArrayIds<T: RawDeviceId, const N: usize> {
+-    ids: [T::RawType; N],
+-    sentinel: T::RawType,
++pub struct IdArrayIds<const N: usize> {
++    ids: [bindings::of_device_id; N],
++    sentinel: bindings::of_device_id,
+ }
+ 
+-unsafe impl<T: RawDeviceId, const N: usize> Sync for IdArrayIds<T, N> {}
++unsafe impl<const N: usize> Sync for IdArrayIds<N> {}
+ 
+ /// A zero-terminated device id array, followed by context data.
+ #[repr(C)]
+-pub struct IdArray<T: RawDeviceId, U, const N: usize> {
+-    ids: IdArrayIds<T, N>,
++pub struct IdArray<U, const N: usize> {
++    ids: IdArrayIds<N>,
+     id_infos: [Option<U>; N],
+ }
+ 
+-impl<T: RawDeviceId, U, const N: usize> IdArray<T, U, N> {
++impl<U, const N: usize> IdArray<U, N> {
+     /// Creates a new instance of the array.
+     ///
+     /// The contents are derived from the given identifiers and context information.
+-    pub const fn new(ids: [T; N], infos: [Option<U>; N]) -> Self
++    pub const fn new(ids: [crate::of::DeviceId; N], infos: [Option<U>; N]) -> Self
+     where
+-        T: ~const RawDeviceId + Copy,
+-        T::RawType: Copy + Clone,
+     {
+         let mut array = Self {
+             ids: IdArrayIds {
+-                ids: [T::ZERO; N],
+-                sentinel: T::ZERO,
++                ids: [crate::of::DEVICEID_ZERO; N],
++                sentinel: crate::of::DEVICEID_ZERO,
+             },
+             id_infos: infos,
+         };
+@@ -191,7 +158,7 @@ impl<T: RawDeviceId, U, const N: usize> IdArray<T, U, N> {
+     /// Returns an `IdTable` backed by `self`.
+     ///
+     /// This is used to essentially erase the array size.
+-    pub const fn as_table(&self) -> IdTable<'_, T, U> {
++    pub const fn as_table(&self) -> IdTable<'_, U> {
+         IdTable {
+             first: &self.ids.ids[0],
+             _p: PhantomData,
+@@ -204,10 +171,7 @@ pub const fn count(&self) -> usize {
+     }
+ 
+     /// Returns the inner IdArrayIds array, without the context data.
+-    pub const fn as_ids(&self) -> IdArrayIds<T, N>
+-    where
+-        T: ~const RawDeviceId + Copy,
+-    {
++    pub const fn as_ids(&self) -> IdArrayIds<N> {
+         self.ids
+     }
+ }
+@@ -216,13 +180,13 @@ pub const fn as_ids(&self) -> IdArrayIds<T, N>
+ ///
+ /// The table is guaranteed to be zero-terminated and to be followed by an array of context data of
+ /// type `Option<U>`.
+-pub struct IdTable<'a, T: RawDeviceId, U> {
+-    first: &'a T::RawType,
++pub struct IdTable<'a, U> {
++    first: &'a bindings::of_device_id,
+     _p: PhantomData<&'a U>,
+ }
+ 
+-impl<T: RawDeviceId, U> AsRef<T::RawType> for IdTable<'_, T, U> {
+-    fn as_ref(&self) -> &T::RawType {
++impl<U> AsRef<bindings::of_device_id> for IdTable<'_, U> {
++    fn as_ref(&self) -> &bindings::of_device_id {
+         self.first
+     }
+ }
+@@ -364,11 +328,11 @@ macro_rules! second_item {
+ /// ```
+ #[macro_export]
+ macro_rules! define_id_array {
+-    ($table_name:ident, $id_type:ty, $data_type:ty, [ $($t:tt)* ]) => {
++    ($table_name:ident, $data_type:ty, [ $($t:tt)* ]) => {
+         const $table_name:
+-            $crate::driver::IdArray<$id_type, $data_type, { $crate::count_paren_items!($($t)*) }> =
++            $crate::driver::IdArray<$data_type, { $crate::count_paren_items!($($t)*) }> =
+                 $crate::driver::IdArray::new(
+-                    $crate::first_item!($id_type, $($t)*), $crate::second_item!($($t)*));
++                    $crate::first_item!(crate::of::DeviceId, $($t)*), $crate::second_item!($($t)*));
+     };
+ }
+ 
+@@ -388,8 +352,8 @@ macro_rules! define_id_array {
+ /// ```
+ #[macro_export]
+ macro_rules! driver_id_table {
+-    ($table_name:ident, $id_type:ty, $data_type:ty, $target:expr) => {
+-        const $table_name: Option<$crate::driver::IdTable<'static, $id_type, $data_type>> =
++    ($table_name:ident, $data_type:ty, $target:expr) => {
++        const $table_name: Option<$crate::driver::IdTable<'static, $data_type>> =
+             Some($target.as_table());
+     };
+ }
+@@ -412,7 +376,7 @@ macro_rules! driver_id_table {
+ macro_rules! module_id_table {
+     ($item_name:ident, $table_type:literal, $id_type:ty, $table_name:ident) => {
+         #[export_name = concat!("__mod_", $table_type, "__", stringify!($table_name), "_device_table")]
+-        static $item_name: $crate::driver::IdArrayIds<$id_type, { $table_name.count() }> =
++        static $item_name: $crate::driver::IdArrayIds<{ $table_name.count() }> =
+             $table_name.as_ids();
+     };
+ }
+diff --git a/rust/kernel/of.rs b/rust/kernel/of.rs
+index a27621b57fbb..0e2a52ee49da 100644
+--- a/rust/kernel/of.rs
++++ b/rust/kernel/of.rs
+@@ -46,7 +46,7 @@ pub enum DeviceId {
+ #[macro_export]
+ macro_rules! define_of_id_table {
+     ($name:ident, $data_type:ty, $($t:tt)*) => {
+-        $crate::define_id_array!($name, $crate::of::DeviceId, $data_type, $($t)*);
++        $crate::define_id_array!($name, $data_type, $($t)*);
+     };
+ }
+ 
+@@ -56,7 +56,6 @@ macro_rules! driver_of_id_table {
+     ($name:expr) => {
+         $crate::driver_id_table!(
+             OF_DEVICE_ID_TABLE,
+-            $crate::of::DeviceId,
+             Self::IdInfo,
+             $name
+         );
+@@ -72,19 +71,18 @@ macro_rules! module_of_id_table {
+     };
+ }
+ 
++pub const DEVICEID_ZERO: bindings::of_device_id = bindings::of_device_id {
++    name: [0; 32],
++    type_: [0; 32],
++    compatible: [0; 128],
++    data: core::ptr::null(),
++};
+ // SAFETY: `ZERO` is all zeroed-out and `to_rawid` stores `offset` in `of_device_id::data`.
+-unsafe impl const driver::RawDeviceId for DeviceId {
+-    type RawType = bindings::of_device_id;
+-    const ZERO: Self::RawType = bindings::of_device_id {
+-        name: [0; 32],
+-        type_: [0; 32],
+-        compatible: [0; 128],
+-        data: core::ptr::null(),
+-    };
++impl DeviceId {
+ 
+-    fn to_rawid(&self, offset: isize) -> Self::RawType {
++    pub const fn to_rawid(&self, offset: isize) -> bindings::of_device_id {
+         let DeviceId::Compatible(compatible) = self;
+-        let mut id = Self::ZERO;
++        let mut id = DEVICEID_ZERO;
+         let mut i = 0;
+         while i < compatible.len() {
+             // If `compatible` does not fit in `id.compatible`, an "index out of bounds" build time
+diff --git a/rust/kernel/platform.rs b/rust/kernel/platform.rs
+index d42ae1cbaf9e..7281351a2b8a 100644
+--- a/rust/kernel/platform.rs
++++ b/rust/kernel/platform.rs
+@@ -140,7 +140,7 @@ pub trait Driver {
+     type IdInfo: 'static = ();
+ 
+     /// The table of device ids supported by the driver.
+-    const OF_DEVICE_ID_TABLE: Option<driver::IdTable<'static, of::DeviceId, Self::IdInfo>> = None;
++    const OF_DEVICE_ID_TABLE: Option<driver::IdTable<'static, Self::IdInfo>> = None;
+ 
+     /// Platform driver probe.
+     ///


### PR DESCRIPTION
Needed for rustc 1.73.0 which is currently in staging-next.

The patch is authored by me. This time around the patch is a bit more involved/hacky. An attempt at an explanation:
rust-next already has a patch for 1.73.0, but rust-next does not contain the driver module of the kernel crate, because that is not yet upstreamed to mainline.
The const_impl unstable feature is being reworked, and I could not make it work, got several compiler panics on the way.
Because the affected RawDeviceId trait is currently only implemented for one single struct, we can just manually insert this DeviceId struct in all the places where RawDeviceId was used as a generic, circumventing the use of const_trait.