### PR TITLE
linux-asahi: Add CONFIG_MUX_APPLE_DPXBAR

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/config
+++ b/apple-silicon-support/packages/linux-asahi/config
@@ -6707,6 +6707,7 @@ CONFIG_MULTIPLEXER=m
 #
 # CONFIG_MUX_ADG792A is not set
 # CONFIG_MUX_ADGS1408 is not set
+CONFIG_MUX_APPLE_DPXBAR=m
 # CONFIG_MUX_GPIO is not set
 # CONFIG_MUX_MMIO is not set
 # end of Multiplexer drivers


### PR DESCRIPTION
Closes https://github.com/tpwrules/nixos-apple-silicon/issues/126

A hacky fix for now since you normally shouldn't manually write into it like this. But at the very least this makes it work until the config is properly synchronized. I tried to find the Fedora config but I don't know where it is.