### PR TITLE
flake support and systemd-initrd

### DIFF
--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -70,6 +70,8 @@
     wormhole-william
   ];
 
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
   # save space and compilation time. might revise?
   hardware.enableAllFirmware = lib.mkForce false;
   hardware.enableRedistributableFirmware = lib.mkForce false;


### PR DESCRIPTION
flake users will fail to build `asahi-peripheral-firmware`

This PR add flake support and implement extract vendor firmware by systemd-initrd

Also, `curl https://alx.sh | sh` install `UEFI + UBoot` will install vendor firmware `/Volumes/EFI - NIXOS/vendorfw/firmware.cpio`. Therefore, I think we don't need `${asahi-fwextract}/bin/asahi-fwextract /tmp/.fwsetup/esp/asahi /tmp/.fwsetup/extracted` again. 