### PR TITLE
flake support

### DIFF
--- a/apple-silicon-support/modules/peripheral-firmware/default.nix
+++ b/apple-silicon-support/modules/peripheral-firmware/default.nix
@@ -1,69 +1,70 @@
 { config, pkgs, lib, ... }:
+let
+  pkgs' = config.hardware.asahi.pkgs;
+in
 {
-  config = {
-    assertions = lib.mkIf config.hardware.asahi.extractPeripheralFirmware [
-      { assertion = config.hardware.asahi.peripheralFirmwareDirectory != null;
-        message = ''
-          Asahi peripheral firmware extraction is enabled but the firmware
-          location appears incorrect.
-        '';
-      }
-    ];
+  options.hardware.asahi.extractPeripheralFirmware = lib.mkOption {
+    type = lib.types.bool;
+    default = true;
+    description = ''
+      Automatically extract the non-free non-redistributable peripheral
+      firmware necessary for features like Wi-Fi.
+    '';
+  };
 
-    hardware.firmware = let
-      pkgs' = config.hardware.asahi.pkgs;
-    in
-      lib.mkIf ((config.hardware.asahi.peripheralFirmwareDirectory != null)
-          && config.hardware.asahi.extractPeripheralFirmware) [
-        (pkgs.stdenv.mkDerivation {
-          name = "asahi-peripheral-firmware";
+  config = lib.mkIf config.hardware.asahi.extractPeripheralFirmware (lib.mkMerge [
+    {
+      environment.systemPackages = [
+        pkgs'.asahi-fwextract
 
-          nativeBuildInputs = [ pkgs'.asahi-fwextract pkgs.cpio ];
-
-          buildCommand = ''
-            mkdir extracted
-            asahi-fwextract ${config.hardware.asahi.peripheralFirmwareDirectory} extracted
-
-            mkdir -p $out/lib/firmware
-            cat extracted/firmware.cpio | cpio -id --quiet --no-absolute-filenames
-            mv vendorfw/* $out/lib/firmware
-          '';
-        })
+        (pkgs.writeShellScriptBin "asahi-fwupdate" ''
+          [ -e /boot/vendorfw.old ] && rm -rf /boot/vendorfw.old
+          mv /boot/vendorfw /boot/vendorfw.old
+          mkdir /boot/vendorfw
+          asahi-fwextract /boot/asahi /boot/vendorfw
+          echo "vendor firmware update success, please reboot"
+        '')
       ];
-  };
 
-  options.hardware.asahi = {
-    extractPeripheralFirmware = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = ''
-        Automatically extract the non-free non-redistributable peripheral
-        firmware necessary for features like Wi-Fi.
+      fileSystems."/boot".neededForBoot = true;
+      fileSystems."/lib/firmware" = {
+        device = "none";
+        fsType = "tmpfs";
+        options = [ "mode=755" ];
+        neededForBoot = true;
+      };
+    }
+
+    (lib.mkIf config.boot.initrd.systemd.enable {
+      boot.initrd.systemd.extraBin = {
+        cpio = "${pkgs.cpio}/bin/cpio";
+      };
+
+      boot.initrd.systemd.services.asahi-vendor-firmware = {
+        after = [ "initrd-fs.target" ];
+        before = [ "initrd.target" ];
+        serviceConfig.Type = "oneshot";
+        script = ''
+          mkdir -p /tmp/.fwsetup/
+          cd /tmp/.fwsetup/
+          cat /sysroot/boot/vendorfw/firmware.cpio | cpio -id --quiet --no-absolute-filenames
+          mv vendorfw/*  /sysroot/lib/firmware
+          rm -rf /tmp/.fwsetup
+        '';
+        wantedBy = [ "initrd.target" ];
+      };
+    })
+
+    (lib.mkIf (!config.boot.initrd.systemd.enable) {
+      boot.initrd.postMountCommands = ''
+        mkdir -p /tmp/.fwsetup/
+        cd /tmp/.fwsetup/
+        cat /mnt-root/boot/vendorfw/firmware.cpio | ${pkgs.cpio}/bin/cpio -id --quiet --no-absolute-filenames
+        mv vendorfw/*  /mnt-root/lib/firmware
+        rm -rf /tmp/.fwsetup
       '';
-    };
+    })
 
-    peripheralFirmwareDirectory = lib.mkOption {
-      type = lib.types.nullOr lib.types.path;
 
-      default = lib.findFirst (path: builtins.pathExists (path + "/all_firmware.tar.gz")) null
-        [
-          # path when the system is operating normally
-          /boot/asahi
-          # path when the system is mounted in the installer
-          /mnt/boot/asahi
-        ];
-
-      description = ''
-        Path to the directory containing the non-free non-redistributable
-        peripheral firmware necessary for features like Wi-Fi. Ordinarily, this
-        will automatically point to the appropriate location on the ESP. Flake
-        users and those interested in maximum purity will want to copy those
-        files elsewhere and specify this manually.
-
-        Currently, this consists of the files `all-firmware.tar.gz` and
-        `kernelcache*`. The official Asahi Linux installer places these files
-        in the `asahi` directory of the EFI system partition when creating it.
-      '';
-    };
-  };
+  ]);
 }

--- a/docs/uefi-standalone.md
+++ b/docs/uefi-standalone.md
@@ -236,15 +236,9 @@ If you used the cross-compiled installer image, i.e. you downloaded the ISO from
 
 The configuration above is the minimum required to produce a bootable system, but you can further edit the file as desired to perform additional configuration. Uncomment the relevant options and change their values as explained in the file. Note that some advertised features may not work properly at this time. Refer to the [NixOS installation manual](https://nixos.org/manual/nixos/stable/index.html#ch-configuration) for further guidance.
 
-Various non-free non-redistributable peripheral firmware files are required to use system hardware like Wi-Fi. The Asahi Linux installer grabs these from macOS and stores them on the EFI system partition when it is created. The NixOS installer loads them from there while booting so that all hardware is available during installation. By default, the Apple Silicon support module will automatically reference the files in the EFI system partition and incorporate them into your configuration to be managed by the normal NixOS mechanisms.
+Various non-free non-redistributable peripheral firmware files are required to use system hardware like Wi-Fi. The Asahi Linux installer grabs these from macOS and stores them on the EFI system partition when it is created. The NixOS installer loads them from there while booting so that all hardware is available during installation. By default, the Apple Silicon support module will automatically mount a tmpfs on /lib/firmware/ and copy firmwares to it during initrd
 
-Currently, the only supported way to update the peripheral firmware files is to destroy and re-create the EFI system partition, so they will not change unexpectedly. If you do not want the impurity of referencing them (or are using flakes where this is prohibited), copy them off the EFI system partition (e.g. on the installation ISO `mkdir -p /mnt/etc/nixos/firmware && cp /mnt/boot/asahi/{all_firmware.tar.gz,kernelcache*} /mnt/etc/nixos/firmware`) and specify this path in your configuration:
-```
-  # Specify path to peripheral firmware files.
-  hardware.asahi.peripheralFirmwareDirectory = ./firmware;
-  # Or disable extraction and management of them completely.
-  # hardware.asahi.extractPeripheralFirmware = false;
-```
+Currently, the only supported way to update the peripheral firmware files is to destroy and re-create the EFI system partition, so they will not change unexpectedly.
 
 <details>
   <summary>If you have apps incompatible with 16K page sizes and you need 4K page size instead...</summary>

--- a/iso-configuration/installer-configuration.nix
+++ b/iso-configuration/installer-configuration.nix
@@ -59,6 +59,8 @@
   # (and is automatically extracted at boot above)
   hardware.asahi.extractPeripheralFirmware = false;
 
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
   isoImage.squashfsCompression = "zstd -Xcompression-level 6";
 
   environment.systemPackages = with pkgs; [


### PR DESCRIPTION
Compared to #128, `systemd-initrd` and `traditional initrd` are both supported. `flake` and `systemd-initrd` are non-mandatory.

I haven't tested the traditional initrd, I think it should work. 

>The problem here is that /Volumes/EFI - NIXOS/vendorfw/firmware.cpio can become out of date when asahi-fwextract gets upgraded. But so too can the all_firmware.tar.gz and the macOS stub partition. All three have happened so far.

>My preferred solution would be to have a derivation download and extract the firmware from the Apple recovery image, but that's pretty gnarly and does not solve the third problem.

This is a temporary solution for better flake user experience. 