### PR TITLE
modules/sound: environment.etc breaks for wireplumber

### DIFF
--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -51,11 +51,11 @@
 
     # set up enivronment so that asahi-audio and UCM configs are used
     environment.etc.asahi-audio-pipewire = {
-      source = "${pkgs.asahi-audio}/share/pipewire";
+      source = "${pkgs.asahi-audio}/share/pipewire/*";
       target = "pipewire";
     };
     environment.etc.asahi-audio-wireplumber = {
-      source = "${pkgs.asahi-audio}/share/wireplumber";
+      source = "${pkgs.asahi-audio}/share/wireplumber/*";
       target = "wireplumber";
     };
     environment.variables.ALSA_CONFIG_UCM2 = "${pkgs.alsa-ucm-conf-asahi}/share/alsa/ucm2";


### PR DESCRIPTION
I opened PR #131 

This changes fixes my specific issue, but an ls -l on /etc/wireplumber reveals that these directories are still linked.

```
total 20K
dr-xr-xr-x 2 root root 4,0K Jan  1  1970 bluetooth.lua.d
lrwxrwxrwx 1 root root   88 Jan  1  1970 main.lua.d -> /nix/store/nd55a8h6lq45zz2aq77pwcp3cwsin4s2-asahi-audio-1.6/share/wireplumber/main.lua.d
lrwxrwxrwx 1 root root   90 Jan  1  1970 policy.lua.d -> /nix/store/nd55a8h6lq45zz2aq77pwcp3cwsin4s2-asahi-audio-1.6/share/wireplumber/policy.lua.d
lrwxrwxrwx 1 root root   85 Jan  1  1970 scripts -> /nix/store/nd55a8h6lq45zz2aq77pwcp3cwsin4s2-asahi-audio-1.6/share/wireplumber/scripts
lrwxrwxrwx 1 root root   96 Jan  1  1970 wireplumber.conf.d -> /nix/store/nd55a8h6lq45zz2aq77pwcp3cwsin4s2-asahi-audio-1.6/share/wireplumber/wireplumber.conf.d
```

Looking at the implementation of the environment.etc-module, this would not change, even if we change the mode of the asahi-audio branch from symlink to an octal, forcing a copy of these files, the etc-package would still be symlinked.