### PR TITLE
mesa-asahi-edge: update disk cache patch

### DIFF
--- a/apple-silicon-support/packages/mesa-asahi-edge/disk_cache-include-dri-driver-path-in-cache-key.patch
+++ b/apple-silicon-support/packages/mesa-asahi-edge/disk_cache-include-dri-driver-path-in-cache-key.patch
@@ -1,16 +1,8 @@
-Author: David McFarland <corngood@gmail.com>
-Date:   Mon Aug 6 15:52:11 2018 -0300
-
-    [PATCH] disk_cache: include dri driver path in cache key
-    
-    This fixes invalid cache hits on NixOS where all shared library
-    timestamps in /nix/store are zero.
-
 diff --git a/meson_options.txt b/meson_options.txt
-index 512e05d..93001da 100644
+index 591ed957c85..6cb550593e3 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -513,6 +513,13 @@ option(
+@@ -519,6 +519,13 @@ option(
    description : 'Enable direct rendering in GLX and EGL for DRI',
  )
  
@@ -25,10 +17,10 @@ index 512e05d..93001da 100644
    type : 'string',
    value : '',
 diff --git a/src/util/disk_cache.c b/src/util/disk_cache.c
-index 8298f9d..e622133 100644
+index 1d23b92af7e..fbb4b04f3cf 100644
 --- a/src/util/disk_cache.c
 +++ b/src/util/disk_cache.c
-@@ -226,8 +226,10 @@ disk_cache_type_create(const char *gpu_name,
+@@ -218,8 +218,10 @@ disk_cache_type_create(const char *gpu_name,
  
     /* Create driver id keys */
     size_t id_size = strlen(driver_id) + 1;
@@ -39,7 +31,7 @@ index 8298f9d..e622133 100644
     cache->driver_keys_blob_size += gpu_name_size;
  
     /* We sometimes store entire structs that contains a pointers in the cache,
-@@ -248,6 +250,7 @@ disk_cache_type_create(const char *gpu_name,
+@@ -240,6 +242,7 @@ disk_cache_type_create(const char *gpu_name,
     uint8_t *drv_key_blob = cache->driver_keys_blob;
     DRV_KEY_CPY(drv_key_blob, &cache_version, cv_size)
     DRV_KEY_CPY(drv_key_blob, driver_id, id_size)
@@ -48,10 +40,10 @@ index 8298f9d..e622133 100644
     DRV_KEY_CPY(drv_key_blob, &ptr_size, ptr_size_size)
     DRV_KEY_CPY(drv_key_blob, &driver_flags, driver_flags_size)
 diff --git a/src/util/meson.build b/src/util/meson.build
-index c0c1b9d..442163c 100644
+index eb88f235c47..eae5c54cc10 100644
 --- a/src/util/meson.build
 +++ b/src/util/meson.build
-@@ -268,7 +268,12 @@ _libmesa_util = static_library(
+@@ -286,7 +286,12 @@ _libmesa_util = static_library(
    include_directories : [inc_util, include_directories('format')],
    dependencies : deps_for_libmesa_util,
    link_with: [libmesa_util_sse41],


### PR DESCRIPTION
This patch hasn't been updated in five months, and the line numbers don't match the state of the code in the asahi-20231213 tag.

This new version of the patch is taken verbatim from nixpkgs HEAD.  Verified via manual inspection that the line numbers match the asahi-20231213 tag.