### PR TITLE
uboot-asahi: bug fixes and config updates

### DIFF
--- a/apple-silicon-support/packages/uboot-asahi/01c76f1a64ba8cb3da9b26be481e289ee16960f0.patch
+++ b/apple-silicon-support/packages/uboot-asahi/01c76f1a64ba8cb3da9b26be481e289ee16960f0.patch
@@ -1,0 +1,29 @@
+From 01c76f1a64ba8cb3da9b26be481e289ee16960f0 Mon Sep 17 00:00:00 2001
+From: Bin Meng <bmeng@tinylab.org>
+Date: Thu, 3 Aug 2023 17:32:41 +0800
+Subject: [PATCH] video: vidconsole: Fix null dereference of ops->measure
+
+At present vidconsole_measure() tests ops->select_font before calling
+ops->measure, which would result in a null dereference when the console
+driver provides no ops for measure.
+
+Fixes: b828ed7d7929 ("console: Allow measuring the bounding box of text")
+Signed-off-by: Bin Meng <bmeng@tinylab.org>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/vidconsole-uclass.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index 05f930478096..b5b3b6625902 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -603,7 +603,7 @@ int vidconsole_measure(struct udevice *dev, const char *name, uint size,
+ 	struct vidconsole_ops *ops = vidconsole_get_ops(dev);
+ 	int ret;
+ 
+-	if (ops->select_font) {
++	if (ops->measure) {
+ 		ret = ops->measure(dev, name, size, text, bbox);
+ 		if (ret != -ENOSYS)
+ 			return ret;

--- a/apple-silicon-support/packages/uboot-asahi/04f3dcd503a537fab50329686874559dae8a1a22.patch
+++ b/apple-silicon-support/packages/uboot-asahi/04f3dcd503a537fab50329686874559dae8a1a22.patch
@@ -1,0 +1,3235 @@
+From 04f3dcd503a537fab50329686874559dae8a1a22 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Thu, 1 Jun 2023 10:23:04 -0600
+Subject: [PATCH] video: Update stb_truetype
+
+This was brought in in 2016 and a number of changes have been made since
+then. There does not seem to be much change in functionality, but it is
+a good idea to update from time to time.
+
+Bring in the latest version:
+
+   5736b15 ("re-add perlin noise again")
+
+Add a few necessary functions, with dummies in some cases. Update the tests
+as there are subtle changes in rendering, perhaps not for the better.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c |   33 +
+ drivers/video/stb_truetype.h     | 2257 +++++++++++++++++++++++++++---
+ test/dm/video.c                  |    6 +-
+ 3 files changed, 2077 insertions(+), 219 deletions(-)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 288123a2e065..0f9bb49e44f7 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -62,10 +62,43 @@ static double tt_sqrt(double value)
+ 	return lo;
+ }
+ 
++static double tt_fmod(double x, double y)
++{
++	double rem;
++
++	if (y == 0.0)
++		return 0.0;
++	rem = x - (x / y) * y;
++
++	return rem;
++}
++
++/* dummy implementation */
++static double tt_pow(double x, double y)
++{
++	return 0;
++}
++
++/* dummy implementation */
++static double tt_cos(double val)
++{
++	return 0;
++}
++
++/* dummy implementation */
++static double tt_acos(double val)
++{
++	return 0;
++}
++
+ #define STBTT_ifloor		tt_floor
+ #define STBTT_iceil		tt_ceil
+ #define STBTT_fabs		tt_fabs
+ #define STBTT_sqrt		tt_sqrt
++#define STBTT_pow		tt_pow
++#define STBTT_fmod		tt_fmod
++#define STBTT_cos		tt_cos
++#define STBTT_acos		tt_acos
+ #define STBTT_malloc(size, u)	((void)(u), malloc(size))
+ #define STBTT_free(size, u)	((void)(u), free(size))
+ #define STBTT_assert(x)
+diff --git a/drivers/video/stb_truetype.h b/drivers/video/stb_truetype.h
+index 438bfce468c7..c6973bb353c3 100644
+--- a/drivers/video/stb_truetype.h
++++ b/drivers/video/stb_truetype.h
+@@ -1,11 +1,21 @@
+-// stb_truetype.h - v1.08 - public domain
+-// authored from 2009-2015 by Sean Barrett / RAD Game Tools
++// stb_truetype.h - v1.26 - public domain
++// authored from 2009-2021 by Sean Barrett / RAD Game Tools
++//
++// =======================================================================
++//
++//    NO SECURITY GUARANTEE -- DO NOT USE THIS ON UNTRUSTED FONT FILES
++//
++// This library does no range checking of the offsets found in the file,
++// meaning an attacker can use it to read arbitrary memory.
++//
++// =======================================================================
+ //
+ //   This library processes TrueType files:
+ //        parse files
+ //        extract glyph metrics
+ //        extract glyph shapes
+ //        render glyphs to one-channel bitmaps with antialiasing (box filter)
++//        render glyphs to one-channel SDF bitmaps (signed-distance field/function)
+ //
+ //   Todo:
+ //        non-MS cmaps
+@@ -20,58 +30,68 @@
+ //
+ //   Mikko Mononen: compound shape support, more cmap formats
+ //   Tor Andersson: kerning, subpixel rendering
+-//
+-//   Bug/warning reports/fixes:
+-//       "Zer" on mollyrocket (with fix)
+-//       Cass Everitt
+-//       stoiko (Haemimont Games)
+-//       Brian Hook 
+-//       Walter van Niftrik
+-//       David Gow
+-//       David Given
+-//       Ivan-Assen Ivanov
+-//       Anthony Pesch
+-//       Johan Duparc
+-//       Hou Qiming
+-//       Fabian "ryg" Giesen
+-//       Martins Mozeiko
+-//       Cap Petschulat
+-//       Omar Cornut
+-//       github:aloucks
+-//       Peter LaValle
+-//       Sergey Popov
+-//       Giumo X. Clanjor
+-//       Higor Euripedes
++//   Dougall Johnson: OpenType / Type 2 font handling
++//   Daniel Ribeiro Maciel: basic GPOS-based kerning
+ //
+ //   Misc other:
+ //       Ryan Gordon
++//       Simon Glass
++//       github:IntellectualKitty
++//       Imanol Celaya
++//       Daniel Ribeiro Maciel
++//
++//   Bug/warning reports/fixes:
++//       "Zer" on mollyrocket       Fabian "ryg" Giesen   github:NiLuJe
++//       Cass Everitt               Martins Mozeiko       github:aloucks
++//       stoiko (Haemimont Games)   Cap Petschulat        github:oyvindjam
++//       Brian Hook                 Omar Cornut           github:vassvik
++//       Walter van Niftrik         Ryan Griege
++//       David Gow                  Peter LaValle
++//       David Given                Sergey Popov
++//       Ivan-Assen Ivanov          Giumo X. Clanjor
++//       Anthony Pesch              Higor Euripedes
++//       Johan Duparc               Thomas Fields
++//       Hou Qiming                 Derek Vinyard
++//       Rob Loach                  Cort Stratton
++//       Kenney Phillis Jr.         Brian Costabile
++//       Ken Voskuil (kaesve)
+ //
+ // VERSION HISTORY
+ //
++//   1.26 (2021-08-28) fix broken rasterizer
++//   1.25 (2021-07-11) many fixes
++//   1.24 (2020-02-05) fix warning
++//   1.23 (2020-02-02) query SVG data for glyphs; query whole kerning table (but only kern not GPOS)
++//   1.22 (2019-08-11) minimize missing-glyph duplication; fix kerning if both 'GPOS' and 'kern' are defined
++//   1.21 (2019-02-25) fix warning
++//   1.20 (2019-02-07) PackFontRange skips missing codepoints; GetScaleFontVMetrics()
++//   1.19 (2018-02-11) GPOS kerning, STBTT_fmod
++//   1.18 (2018-01-29) add missing function
++//   1.17 (2017-07-23) make more arguments const; doc fix
++//   1.16 (2017-07-12) SDF support
++//   1.15 (2017-03-03) make more arguments const
++//   1.14 (2017-01-16) num-fonts-in-TTC function
++//   1.13 (2017-01-02) support OpenType fonts, certain Apple fonts
++//   1.12 (2016-10-25) suppress warnings about casting away const with -Wcast-qual
++//   1.11 (2016-04-02) fix unused-variable warning
++//   1.10 (2016-04-02) user-defined fabs(); rare memory leak; remove duplicate typedef
++//   1.09 (2016-01-16) warning fix; avoid crash on outofmem; use allocation userdata properly
+ //   1.08 (2015-09-13) document stbtt_Rasterize(); fixes for vertical & horizontal edges
+ //   1.07 (2015-08-01) allow PackFontRanges to accept arrays of sparse codepoints;
+ //                     variant PackFontRanges to pack and render in separate phases;
+ //                     fix stbtt_GetFontOFfsetForIndex (never worked for non-0 input?);
+ //                     fixed an assert() bug in the new rasterizer
+ //                     replace assert() with STBTT_assert() in new rasterizer
+-//   1.06 (2015-07-14) performance improvements (~35% faster on x86 and x64 on test machine)
+-//                     also more precise AA rasterizer, except if shapes overlap
+-//                     remove need for STBTT_sort
+-//   1.05 (2015-04-15) fix misplaced definitions for STBTT_STATIC
+-//   1.04 (2015-04-15) typo in example
+-//   1.03 (2015-04-12) STBTT_STATIC, fix memory leak in new packing, various fixes
+ //
+ //   Full history can be found at the end of this file.
+ //
+ // LICENSE
+ //
+-//   This software is in the public domain. Where that dedication is not
+-//   recognized, you are granted a perpetual, irrevocable license to copy,
+-//   distribute, and modify this file as you see fit.
++//   See end of file for license information.
+ //
+ // USAGE
+ //
+-//   Include this file in whatever places neeed to refer to it. In ONE C/C++
++//   Include this file in whatever places need to refer to it. In ONE C/C++
+ //   file, write:
+ //      #define STB_TRUETYPE_IMPLEMENTATION
+ //   before the #include of this file. This expands out the actual
+@@ -87,14 +107,15 @@
+ //   Improved 3D API (more shippable):
+ //           #include "stb_rect_pack.h"           -- optional, but you really want it
+ //           stbtt_PackBegin()
+-//           stbtt_PackSetOversample()            -- for improved quality on small fonts
++//           stbtt_PackSetOversampling()          -- for improved quality on small fonts
+ //           stbtt_PackFontRanges()               -- pack and renders
+ //           stbtt_PackEnd()
+ //           stbtt_GetPackedQuad()
+ //
+ //   "Load" a font file from a memory buffer (you have to keep the buffer loaded)
+ //           stbtt_InitFont()
+-//           stbtt_GetFontOffsetForIndex()        -- use for TTC font collections
++//           stbtt_GetFontOffsetForIndex()        -- indexing for TTC font collections
++//           stbtt_GetNumberOfFonts()             -- number of fonts for TTC font collections
+ //
+ //   Render a unicode codepoint to a bitmap
+ //           stbtt_GetCodepointBitmap()           -- allocates and returns a bitmap
+@@ -104,6 +125,7 @@
+ //   Character advance/positioning
+ //           stbtt_GetCodepointHMetrics()
+ //           stbtt_GetFontVMetrics()
++//           stbtt_GetFontVMetricsOS2()
+ //           stbtt_GetCodepointKernAdvance()
+ //
+ //   Starting with version 1.06, the rasterizer was replaced with a new,
+@@ -159,7 +181,7 @@
+ //         measurement for describing font size, defined as 72 points per inch.
+ //         stb_truetype provides a point API for compatibility. However, true
+ //         "per inch" conventions don't make much sense on computer displays
+-//         since they different monitors have different number of pixels per
++//         since different monitors have different number of pixels per
+ //         inch. For example, Windows traditionally uses a convention that
+ //         there are 96 pixels per inch, thus making 'inch' measurements have
+ //         nothing to do with inches, and thus effectively defining a point to
+@@ -169,6 +191,39 @@
+ //         for non-commercial fonts, thus making fonts scaled in points
+ //         according to the TrueType spec incoherently sized in practice.
+ //
++// DETAILED USAGE:
++//
++//  Scale:
++//    Select how high you want the font to be, in points or pixels.
++//    Call ScaleForPixelHeight or ScaleForMappingEmToPixels to compute
++//    a scale factor SF that will be used by all other functions.
++//
++//  Baseline:
++//    You need to select a y-coordinate that is the baseline of where
++//    your text will appear. Call GetFontBoundingBox to get the baseline-relative
++//    bounding box for all characters. SF*-y0 will be the distance in pixels
++//    that the worst-case character could extend above the baseline, so if
++//    you want the top edge of characters to appear at the top of the
++//    screen where y=0, then you would set the baseline to SF*-y0.
++//
++//  Current point:
++//    Set the current point where the first character will appear. The
++//    first character could extend left of the current point; this is font
++//    dependent. You can either choose a current point that is the leftmost
++//    point and hope, or add some padding, or check the bounding box or
++//    left-side-bearing of the first character to be displayed and set
++//    the current point based on that.
++//
++//  Displaying a character:
++//    Compute the bounding box of the character. It will contain signed values
++//    relative to <current_point, baseline>. I.e. if it returns x0,y0,x1,y1,
++//    then the character should be displayed in the rectangle from
++//    <current_point+SF*x0, baseline+SF*y0> to <current_point+SF*x1,baseline+SF*y1).
++//
++//  Advancing for the next character:
++//    Call GlyphHMetrics, and compute 'current_point += SF * advance'.
++//
++//
+ // ADVANCED USAGE
+ //
+ //   Quality:
+@@ -203,19 +258,6 @@
+ //   recommend it.
+ //
+ //
+-// SOURCE STATISTICS (based on v0.6c, 2050 LOC)
+-//
+-//   Documentation & header file        520 LOC  \___ 660 LOC documentation
+-//   Sample code                        140 LOC  /
+-//   Truetype parsing                   620 LOC  ---- 620 LOC TrueType
+-//   Software rasterization             240 LOC  \                           .
+-//   Curve tesselation                  120 LOC   \__ 550 LOC Bitmap creation
+-//   Bitmap management                  100 LOC   /
+-//   Baked bitmap interface              70 LOC  /
+-//   Font name matching & access        150 LOC  ---- 150 
+-//   C runtime library abstraction       60 LOC  ----  60
+-//
+-//
+ // PERFORMANCE MEASUREMENTS FOR 1.06:
+ //
+ //                      32-bit     64-bit
+@@ -230,8 +272,8 @@
+ ////  SAMPLE PROGRAMS
+ ////
+ //
+-//  Incomplete text-in-3d-api example, which draws quads properly aligned to be lossless
+-//
++//  Incomplete text-in-3d-api example, which draws quads properly aligned to be lossless.
++//  See "tests/truetype_demo_win32.c" for a complete version.
+ #if 0
+ #define STB_TRUETYPE_IMPLEMENTATION  // force following include to generate implementation
+ #include "stb_truetype.h"
+@@ -257,6 +299,8 @@ void my_stbtt_initfont(void)
+ void my_stbtt_print(float x, float y, char *text)
+ {
+    // assume orthographic projection with units = screen pixels, origin at top left
++   glEnable(GL_BLEND);
++   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glEnable(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, ftex);
+    glBegin(GL_QUADS);
+@@ -264,10 +308,10 @@ void my_stbtt_print(float x, float y, char *text)
+       if (*text >= 32 && *text < 128) {
+          stbtt_aligned_quad q;
+          stbtt_GetBakedQuad(cdata, 512,512, *text-32, &x,&y,&q,1);//1=opengl & d3d10+,0=d3d9
+-         glTexCoord2f(q.s0,q.t1); glVertex2f(q.x0,q.y0);
+-         glTexCoord2f(q.s1,q.t1); glVertex2f(q.x1,q.y0);
+-         glTexCoord2f(q.s1,q.t0); glVertex2f(q.x1,q.y1);
+-         glTexCoord2f(q.s0,q.t0); glVertex2f(q.x0,q.y1);
++         glTexCoord2f(q.s0,q.t0); glVertex2f(q.x0,q.y0);
++         glTexCoord2f(q.s1,q.t0); glVertex2f(q.x1,q.y0);
++         glTexCoord2f(q.s1,q.t1); glVertex2f(q.x1,q.y1);
++         glTexCoord2f(q.s0,q.t1); glVertex2f(q.x0,q.y1);
+       }
+       ++text;
+    }
+@@ -305,7 +349,7 @@ int main(int argc, char **argv)
+    }
+    return 0;
+ }
+-#endif 
++#endif
+ //
+ // Output:
+ //
+@@ -319,9 +363,9 @@ int main(int argc, char **argv)
+ //  :@@.  M@M
+ //   @@@o@@@@
+ //   :M@@V:@@.
+-//  
++//
+ //////////////////////////////////////////////////////////////////////////////
+-// 
++//
+ // Complete program: print "Hello World!" banner, with bugs
+ //
+ #if 0
+@@ -375,7 +419,8 @@ int main(int arg, char **argv)
+ ////   INTEGRATION WITH YOUR CODEBASE
+ ////
+ ////   The following sections allow you to supply alternate definitions
+-////   of C library functions used by stb_truetype.
++////   of C library functions used by stb_truetype, e.g. if you don't
++////   link with the C runtime library.
+ 
+ #ifdef STB_TRUETYPE_IMPLEMENTATION
+    // #define your own (u)stbtt_int8/16/32 before including to override this
+@@ -391,7 +436,7 @@ int main(int arg, char **argv)
+    typedef char stbtt__check_size32[sizeof(stbtt_int32)==4 ? 1 : -1];
+    typedef char stbtt__check_size16[sizeof(stbtt_int16)==2 ? 1 : -1];
+ 
+-   // #define your own STBTT_ifloor/STBTT_iceil() to avoid math.h
++   // e.g. #define your own STBTT_ifloor/STBTT_iceil() to avoid math.h
+    #ifndef STBTT_ifloor
+    #include <math.h>
+    #define STBTT_ifloor(x)   ((int) floor(x))
+@@ -401,6 +446,18 @@ int main(int arg, char **argv)
+    #ifndef STBTT_sqrt
+    #include <math.h>
+    #define STBTT_sqrt(x)      sqrt(x)
++   #define STBTT_pow(x,y)     pow(x,y)
++   #endif
++
++   #ifndef STBTT_fmod
++   #include <math.h>
++   #define STBTT_fmod(x,y)    fmod(x,y)
++   #endif
++
++   #ifndef STBTT_cos
++   #include <math.h>
++   #define STBTT_cos(x)       cos(x)
++   #define STBTT_acos(x)      acos(x)
+    #endif
+ 
+    #ifndef STBTT_fabs
+@@ -452,6 +509,14 @@ int main(int arg, char **argv)
+ extern "C" {
+ #endif
+ 
++// private structure
++typedef struct
++{
++   unsigned char *data;
++   int cursor;
++   int size;
++} stbtt__buf;
++
+ //////////////////////////////////////////////////////////////////////////////
+ //
+ // TEXTURE BAKING API
+@@ -481,7 +546,7 @@ typedef struct
+    float x1,y1,s1,t1; // bottom-right
+ } stbtt_aligned_quad;
+ 
+-STBTT_DEF void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph,  // same data as above
++STBTT_DEF void stbtt_GetBakedQuad(const stbtt_bakedchar *chardata, int pw, int ph,  // same data as above
+                                int char_index,             // character to display
+                                float *xpos, float *ypos,   // pointers to current position in screen pixel space
+                                stbtt_aligned_quad *q,      // output: quad to draw
+@@ -496,6 +561,9 @@ STBTT_DEF void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph,  //
+ //
+ // It's inefficient; you might want to c&p it and optimize it.
+ 
++STBTT_DEF void stbtt_GetScaledFontVMetrics(const unsigned char *fontdata, int index, float size, float *ascent, float *descent, float *lineGap);
++// Query the font vertical metrics without having to create a font first.
++
+ 
+ //////////////////////////////////////////////////////////////////////////////
+ //
+@@ -520,7 +588,7 @@ typedef struct stbrp_rect stbrp_rect;
+ STBTT_DEF int  stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, int width, int height, int stride_in_bytes, int padding, void *alloc_context);
+ // Initializes a packing context stored in the passed-in stbtt_pack_context.
+ // Future calls using this context will pack characters into the bitmap passed
+-// in here: a 1-channel bitmap that is weight x height. stride_in_bytes is
++// in here: a 1-channel bitmap that is width * height. stride_in_bytes is
+ // the distance from one row to the next (or 0 to mean they are packed tightly
+ // together). "padding" is the amount of padding to leave between each
+ // character (normally you want '1' for bitmaps you'll use as textures with
+@@ -533,7 +601,7 @@ STBTT_DEF void stbtt_PackEnd  (stbtt_pack_context *spc);
+ 
+ #define STBTT_POINT_SIZE(x)   (-(x))
+ 
+-STBTT_DEF int  stbtt_PackFontRange(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, float font_size,
++STBTT_DEF int  stbtt_PackFontRange(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, float font_size,
+                                 int first_unicode_char_in_range, int num_chars_in_range, stbtt_packedchar *chardata_for_range);
+ // Creates character bitmaps from the font_index'th font found in fontdata (use
+ // font_index=0 if you don't know what that is). It creates num_chars_in_range
+@@ -558,7 +626,7 @@ typedef struct
+    unsigned char h_oversample, v_oversample; // don't set these, they're used internally
+ } stbtt_pack_range;
+ 
+-STBTT_DEF int  stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges);
++STBTT_DEF int  stbtt_PackFontRanges(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges);
+ // Creates character bitmaps from multiple ranges of characters stored in
+ // ranges. This will usually create a better-packed bitmap than multiple
+ // calls to stbtt_PackFontRange. Note that you can call this multiple
+@@ -580,19 +648,25 @@ STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h
+ // To use with PackFontRangesGather etc., you must set it before calls
+ // call to PackFontRangesGatherRects.
+ 
+-STBTT_DEF void stbtt_GetPackedQuad(stbtt_packedchar *chardata, int pw, int ph,  // same data as above
++STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context *spc, int skip);
++// If skip != 0, this tells stb_truetype to skip any codepoints for which
++// there is no corresponding glyph. If skip=0, which is the default, then
++// codepoints without a glyph recived the font's "missing character" glyph,
++// typically an empty box by convention.
++
++STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata, int pw, int ph,  // same data as above
+                                int char_index,             // character to display
+                                float *xpos, float *ypos,   // pointers to current position in screen pixel space
+                                stbtt_aligned_quad *q,      // output: quad to draw
+                                int align_to_integer);
+ 
+-STBTT_DEF int  stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
++STBTT_DEF int  stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
+ STBTT_DEF void stbtt_PackFontRangesPackRects(stbtt_pack_context *spc, stbrp_rect *rects, int num_rects);
+-STBTT_DEF int  stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
++STBTT_DEF int  stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects);
+ // Calling these functions in sequence is roughly equivalent to calling
+ // stbtt_PackFontRanges(). If you more control over the packing of multiple
+ // fonts, or if you want to pack custom data into a font texture, take a look
+-// at the source to of stbtt_PackFontRanges() and create a custom version 
++// at the source to of stbtt_PackFontRanges() and create a custom version
+ // using these functions, e.g. call GatherRects multiple times,
+ // building up a single array of rects, then call PackRects once,
+ // then call RenderIntoRects repeatedly. This may result in a
+@@ -608,6 +682,7 @@ struct stbtt_pack_context {
+    int   height;
+    int   stride_in_bytes;
+    int   padding;
++   int   skip_missing;
+    unsigned int   h_oversample, v_oversample;
+    unsigned char *pixels;
+    void  *nodes;
+@@ -619,18 +694,23 @@ struct stbtt_pack_context {
+ //
+ //
+ 
++STBTT_DEF int stbtt_GetNumberOfFonts(const unsigned char *data);
++// This function will determine the number of fonts in a font file.  TrueType
++// collection (.ttc) files may contain multiple fonts, while TrueType font
++// (.ttf) files only contain one font. The number of fonts can be used for
++// indexing with the previous function where the index is between zero and one
++// less than the total fonts. If an error occurs, -1 is returned.
++
+ STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index);
+ // Each .ttf/.ttc file may have more than one font. Each font has a sequential
+ // index number starting from 0. Call this function to get the font offset for
+ // a given index; it returns -1 if the index is out of range. A regular .ttf
+ // file will only define one font and it always be at offset 0, so it will
+-// return '0' for index 0, and -1 for all other indices. You can just skip
+-// this step if you know it's that kind of font.
+-
++// return '0' for index 0, and -1 for all other indices.
+ 
+-// The following structure is defined publically so you can declare one on
++// The following structure is defined publicly so you can declare one on
+ // the stack or as a global or etc, but you should treat it as opaque.
+-typedef struct stbtt_fontinfo
++struct stbtt_fontinfo
+ {
+    void           * userdata;
+    unsigned char  * data;              // pointer to .ttf file
+@@ -638,10 +718,17 @@ typedef struct stbtt_fontinfo
+ 
+    int numGlyphs;                     // number of glyphs, needed for range checking
+ 
+-   int loca,head,glyf,hhea,hmtx,kern; // table locations as offset from start of .ttf
++   int loca,head,glyf,hhea,hmtx,kern,gpos,svg; // table locations as offset from start of .ttf
+    int index_map;                     // a cmap mapping for our chosen character encoding
+    int indexToLocFormat;              // format needed to map from glyph index to glyph
+-} stbtt_fontinfo;
++
++   stbtt__buf cff;                    // cff font data
++   stbtt__buf charstrings;            // the charstring index
++   stbtt__buf gsubrs;                 // global charstring subroutines index
++   stbtt__buf subrs;                  // private charstring subroutines index
++   stbtt__buf fontdicts;              // array of font dicts
++   stbtt__buf fdselect;               // map from glyph to fontdict
++};
+ 
+ STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset);
+ // Given an offset into the file that defines a font, this function builds
+@@ -660,6 +747,7 @@ STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codep
+ // and you want a speed-up, call this function with the character you're
+ // going to process, then use glyph-based functions instead of the
+ // codepoint-based functions.
++// Returns 0 if the character codepoint is not defined in the font.
+ 
+ 
+ //////////////////////////////////////////////////////////////////////////////
+@@ -688,6 +776,12 @@ STBTT_DEF void stbtt_GetFontVMetrics(const stbtt_fontinfo *info, int *ascent, in
+ //   these are expressed in unscaled coordinates, so you must multiply by
+ //   the scale factor for a given size
+ 
++STBTT_DEF int  stbtt_GetFontVMetricsOS2(const stbtt_fontinfo *info, int *typoAscent, int *typoDescent, int *typoLineGap);
++// analogous to GetFontVMetrics, but returns the "typographic" values from the OS/2
++// table (specific to MS/Windows TTF files).
++//
++// Returns 1 on success (table present), 0 on failure.
++
+ STBTT_DEF void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info, int *x0, int *y0, int *x1, int *y1);
+ // the bounding box around all possible characters
+ 
+@@ -707,6 +801,18 @@ STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1,
+ STBTT_DEF int  stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1);
+ // as above, but takes one or more glyph indices for greater efficiency
+ 
++typedef struct stbtt_kerningentry
++{
++   int glyph1; // use stbtt_FindGlyphIndex
++   int glyph2;
++   int advance;
++} stbtt_kerningentry;
++
++STBTT_DEF int  stbtt_GetKerningTableLength(const stbtt_fontinfo *info);
++STBTT_DEF int  stbtt_GetKerningTable(const stbtt_fontinfo *info, stbtt_kerningentry* table, int table_length);
++// Retrieves a complete list of all of the kerning pairs provided by the font
++// stbtt_GetKerningTable never writes more than table_length entries and returns how many entries it did write.
++// The table will be sorted by (a.glyph1 == b.glyph1)?(a.glyph2 < b.glyph2):(a.glyph1 < b.glyph1)
+ 
+ //////////////////////////////////////////////////////////////////////////////
+ //
+@@ -718,7 +824,8 @@ STBTT_DEF int  stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, in
+    enum {
+       STBTT_vmove=1,
+       STBTT_vline,
+-      STBTT_vcurve
++      STBTT_vcurve,
++      STBTT_vcubic
+    };
+ #endif
+ 
+@@ -727,7 +834,7 @@ STBTT_DEF int  stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, in
+    #define stbtt_vertex_type short // can't use stbtt_int16 because that's not visible in the header file
+    typedef struct
+    {
+-      stbtt_vertex_type x,y,cx,cy;
++      stbtt_vertex_type x,y,cx,cy,cx1,cy1;
+       unsigned char type,padding;
+    } stbtt_vertex;
+ #endif
+@@ -740,7 +847,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+ // returns # of vertices and fills *vertices with the pointer to them
+ //   these are expressed in "unscaled" coordinates
+ //
+-// The shape is a series of countours. Each one starts with
++// The shape is a series of contours. Each one starts with
+ // a STBTT_moveto, then consists of a series of mixed
+ // STBTT_lineto and STBTT_curveto segments. A lineto
+ // draws a line from previous endpoint to its x,y; a curveto
+@@ -750,6 +857,12 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+ STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *vertices);
+ // frees the data allocated above
+ 
++STBTT_DEF unsigned char *stbtt_FindSVGDoc(const stbtt_fontinfo *info, int gl);
++STBTT_DEF int stbtt_GetCodepointSVG(const stbtt_fontinfo *info, int unicode_codepoint, const char **svg);
++STBTT_DEF int stbtt_GetGlyphSVG(const stbtt_fontinfo *info, int gl, const char **svg);
++// fills svg with the character's SVG data.
++// returns data size or 0 if SVG not found.
++
+ //////////////////////////////////////////////////////////////////////////////
+ //
+ // BITMAP RENDERING
+@@ -781,6 +894,10 @@ STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, uns
+ // same as stbtt_MakeCodepointBitmap, but you can specify a subpixel
+ // shift for the character
+ 
++STBTT_DEF void stbtt_MakeCodepointBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int oversample_x, int oversample_y, float *sub_x, float *sub_y, int codepoint);
++// same as stbtt_MakeCodepointBitmapSubpixel, but prefiltering
++// is performed (see stbtt_PackSetOversampling)
++
+ STBTT_DEF void stbtt_GetCodepointBitmapBox(const stbtt_fontinfo *font, int codepoint, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
+ // get the bbox of the bitmap centered around the glyph origin; so the
+ // bitmap width is ix1-ix0, height is iy1-iy0, and location to place
+@@ -798,6 +915,7 @@ STBTT_DEF unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float
+ STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int glyph, int *width, int *height, int *xoff, int *yoff);
+ STBTT_DEF void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int glyph);
+ STBTT_DEF void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int glyph);
++STBTT_DEF void stbtt_MakeGlyphBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int oversample_x, int oversample_y, float *sub_x, float *sub_y, int glyph);
+ STBTT_DEF void stbtt_GetGlyphBitmapBox(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y, int *ix0, int *iy0, int *ix1, int *iy1);
+ STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y,float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1);
+ 
+@@ -820,6 +938,64 @@ STBTT_DEF void stbtt_Rasterize(stbtt__bitmap *result,        // 1-channel bitmap
+                                int invert,                   // if non-zero, vertically flip shape
+                                void *userdata);              // context for to STBTT_MALLOC
+ 
++//////////////////////////////////////////////////////////////////////////////
++//
++// Signed Distance Function (or Field) rendering
++
++STBTT_DEF void stbtt_FreeSDF(unsigned char *bitmap, void *userdata);
++// frees the SDF bitmap allocated below
++
++STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float scale, int glyph, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff);
++STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, float scale, int codepoint, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff);
++// These functions compute a discretized SDF field for a single character, suitable for storing
++// in a single-channel texture, sampling with bilinear filtering, and testing against
++// larger than some threshold to produce scalable fonts.
++//        info              --  the font
++//        scale             --  controls the size of the resulting SDF bitmap, same as it would be creating a regular bitmap
++//        glyph/codepoint   --  the character to generate the SDF for
++//        padding           --  extra "pixels" around the character which are filled with the distance to the character (not 0),
++//                                 which allows effects like bit outlines
++//        onedge_value      --  value 0-255 to test the SDF against to reconstruct the character (i.e. the isocontour of the character)
++//        pixel_dist_scale  --  what value the SDF should increase by when moving one SDF "pixel" away from the edge (on the 0..255 scale)
++//                                 if positive, > onedge_value is inside; if negative, < onedge_value is inside
++//        width,height      --  output height & width of the SDF bitmap (including padding)
++//        xoff,yoff         --  output origin of the character
++//        return value      --  a 2D array of bytes 0..255, width*height in size
++//
++// pixel_dist_scale & onedge_value are a scale & bias that allows you to make
++// optimal use of the limited 0..255 for your application, trading off precision
++// and special effects. SDF values outside the range 0..255 are clamped to 0..255.
++//
++// Example:
++//      scale = stbtt_ScaleForPixelHeight(22)
++//      padding = 5
++//      onedge_value = 180
++//      pixel_dist_scale = 180/5.0 = 36.0
++//
++//      This will create an SDF bitmap in which the character is about 22 pixels
++//      high but the whole bitmap is about 22+5+5=32 pixels high. To produce a filled
++//      shape, sample the SDF at each pixel and fill the pixel if the SDF value
++//      is greater than or equal to 180/255. (You'll actually want to antialias,
++//      which is beyond the scope of this example.) Additionally, you can compute
++//      offset outlines (e.g. to stroke the character border inside & outside,
++//      or only outside). For example, to fill outside the character up to 3 SDF
++//      pixels, you would compare against (180-36.0*3)/255 = 72/255. The above
++//      choice of variables maps a range from 5 pixels outside the shape to
++//      2 pixels inside the shape to 0..255; this is intended primarily for apply
++//      outside effects only (the interior range is needed to allow proper
++//      antialiasing of the font at *smaller* sizes)
++//
++// The function computes the SDF analytically at each SDF pixel, not by e.g.
++// building a higher-res bitmap and approximating it. In theory the quality
++// should be as high as possible for an SDF of this size & representation, but
++// unclear if this is true in practice (perhaps building a higher-res bitmap
++// and computing from that can allow drop-out prevention).
++//
++// The algorithm has not been optimized at all, so expect it to be slow
++// if computing lots of characters or very large sizes.
++
++
++
+ //////////////////////////////////////////////////////////////////////////////
+ //
+ // Finding the right font...
+@@ -943,6 +1119,158 @@ typedef int stbtt__test_oversample_pow2[(STBTT_MAX_OVERSAMPLE & (STBTT_MAX_OVERS
+ #define STBTT_RASTERIZER_VERSION 2
+ #endif
+ 
++#ifdef _MSC_VER
++#define STBTT__NOTUSED(v)  (void)(v)
++#else
++#define STBTT__NOTUSED(v)  (void)sizeof(v)
++#endif
++
++//////////////////////////////////////////////////////////////////////////
++//
++// stbtt__buf helpers to parse data from file
++//
++
++static stbtt_uint8 stbtt__buf_get8(stbtt__buf *b)
++{
++   if (b->cursor >= b->size)
++      return 0;
++   return b->data[b->cursor++];
++}
++
++static stbtt_uint8 stbtt__buf_peek8(stbtt__buf *b)
++{
++   if (b->cursor >= b->size)
++      return 0;
++   return b->data[b->cursor];
++}
++
++static void stbtt__buf_seek(stbtt__buf *b, int o)
++{
++   STBTT_assert(!(o > b->size || o < 0));
++   b->cursor = (o > b->size || o < 0) ? b->size : o;
++}
++
++static void stbtt__buf_skip(stbtt__buf *b, int o)
++{
++   stbtt__buf_seek(b, b->cursor + o);
++}
++
++static stbtt_uint32 stbtt__buf_get(stbtt__buf *b, int n)
++{
++   stbtt_uint32 v = 0;
++   int i;
++   STBTT_assert(n >= 1 && n <= 4);
++   for (i = 0; i < n; i++)
++      v = (v << 8) | stbtt__buf_get8(b);
++   return v;
++}
++
++static stbtt__buf stbtt__new_buf(const void *p, size_t size)
++{
++   stbtt__buf r;
++   STBTT_assert(size < 0x40000000);
++   r.data = (stbtt_uint8*) p;
++   r.size = (int) size;
++   r.cursor = 0;
++   return r;
++}
++
++#define stbtt__buf_get16(b)  stbtt__buf_get((b), 2)
++#define stbtt__buf_get32(b)  stbtt__buf_get((b), 4)
++
++static stbtt__buf stbtt__buf_range(const stbtt__buf *b, int o, int s)
++{
++   stbtt__buf r = stbtt__new_buf(NULL, 0);
++   if (o < 0 || s < 0 || o > b->size || s > b->size - o) return r;
++   r.data = b->data + o;
++   r.size = s;
++   return r;
++}
++
++static stbtt__buf stbtt__cff_get_index(stbtt__buf *b)
++{
++   int count, start, offsize;
++   start = b->cursor;
++   count = stbtt__buf_get16(b);
++   if (count) {
++      offsize = stbtt__buf_get8(b);
++      STBTT_assert(offsize >= 1 && offsize <= 4);
++      stbtt__buf_skip(b, offsize * count);
++      stbtt__buf_skip(b, stbtt__buf_get(b, offsize) - 1);
++   }
++   return stbtt__buf_range(b, start, b->cursor - start);
++}
++
++static stbtt_uint32 stbtt__cff_int(stbtt__buf *b)
++{
++   int b0 = stbtt__buf_get8(b);
++   if (b0 >= 32 && b0 <= 246)       return b0 - 139;
++   else if (b0 >= 247 && b0 <= 250) return (b0 - 247)*256 + stbtt__buf_get8(b) + 108;
++   else if (b0 >= 251 && b0 <= 254) return -(b0 - 251)*256 - stbtt__buf_get8(b) - 108;
++   else if (b0 == 28)               return stbtt__buf_get16(b);
++   else if (b0 == 29)               return stbtt__buf_get32(b);
++   STBTT_assert(0);
++   return 0;
++}
++
++static void stbtt__cff_skip_operand(stbtt__buf *b) {
++   int v, b0 = stbtt__buf_peek8(b);
++   STBTT_assert(b0 >= 28);
++   if (b0 == 30) {
++      stbtt__buf_skip(b, 1);
++      while (b->cursor < b->size) {
++         v = stbtt__buf_get8(b);
++         if ((v & 0xF) == 0xF || (v >> 4) == 0xF)
++            break;
++      }
++   } else {
++      stbtt__cff_int(b);
++   }
++}
++
++static stbtt__buf stbtt__dict_get(stbtt__buf *b, int key)
++{
++   stbtt__buf_seek(b, 0);
++   while (b->cursor < b->size) {
++      int start = b->cursor, end, op;
++      while (stbtt__buf_peek8(b) >= 28)
++         stbtt__cff_skip_operand(b);
++      end = b->cursor;
++      op = stbtt__buf_get8(b);
++      if (op == 12)  op = stbtt__buf_get8(b) | 0x100;
++      if (op == key) return stbtt__buf_range(b, start, end-start);
++   }
++   return stbtt__buf_range(b, 0, 0);
++}
++
++static void stbtt__dict_get_ints(stbtt__buf *b, int key, int outcount, stbtt_uint32 *out)
++{
++   int i;
++   stbtt__buf operands = stbtt__dict_get(b, key);
++   for (i = 0; i < outcount && operands.cursor < operands.size; i++)
++      out[i] = stbtt__cff_int(&operands);
++}
++
++static int stbtt__cff_index_count(stbtt__buf *b)
++{
++   stbtt__buf_seek(b, 0);
++   return stbtt__buf_get16(b);
++}
++
++static stbtt__buf stbtt__cff_index_get(stbtt__buf b, int i)
++{
++   int count, offsize, start, end;
++   stbtt__buf_seek(&b, 0);
++   count = stbtt__buf_get16(&b);
++   offsize = stbtt__buf_get8(&b);
++   STBTT_assert(i >= 0 && i < count);
++   STBTT_assert(offsize >= 1 && offsize <= 4);
++   stbtt__buf_skip(&b, i*offsize);
++   start = stbtt__buf_get(&b, offsize);
++   end = stbtt__buf_get(&b, offsize);
++   return stbtt__buf_range(&b, 2+(count+1)*offsize+start, end - start);
++}
++
+ //////////////////////////////////////////////////////////////////////////
+ //
+ // accessors to parse data from file
+@@ -955,32 +1283,22 @@ typedef int stbtt__test_oversample_pow2[(STBTT_MAX_OVERSAMPLE & (STBTT_MAX_OVERS
+ #define ttCHAR(p)     (* (stbtt_int8 *) (p))
+ #define ttFixed(p)    ttLONG(p)
+ 
+-#if defined(STB_TRUETYPE_BIGENDIAN) && !defined(ALLOW_UNALIGNED_TRUETYPE)
+-
+-   #define ttUSHORT(p)   (* (stbtt_uint16 *) (p))
+-   #define ttSHORT(p)    (* (stbtt_int16 *) (p))
+-   #define ttULONG(p)    (* (stbtt_uint32 *) (p))
+-   #define ttLONG(p)     (* (stbtt_int32 *) (p))
+-
+-#else
+-
+-   static stbtt_uint16 ttUSHORT(const stbtt_uint8 *p) { return p[0]*256 + p[1]; }
+-   static stbtt_int16 ttSHORT(const stbtt_uint8 *p)   { return p[0]*256 + p[1]; }
+-   static stbtt_uint32 ttULONG(const stbtt_uint8 *p)  { return (p[0]<<24) + (p[1]<<16) + (p[2]<<8) + p[3]; }
+-   static stbtt_int32 ttLONG(const stbtt_uint8 *p)    { return (p[0]<<24) + (p[1]<<16) + (p[2]<<8) + p[3]; }
+-
+-#endif
++static stbtt_uint16 ttUSHORT(stbtt_uint8 *p) { return p[0]*256 + p[1]; }
++static stbtt_int16 ttSHORT(stbtt_uint8 *p)   { return p[0]*256 + p[1]; }
++static stbtt_uint32 ttULONG(stbtt_uint8 *p)  { return (p[0]<<24) + (p[1]<<16) + (p[2]<<8) + p[3]; }
++static stbtt_int32 ttLONG(stbtt_uint8 *p)    { return (p[0]<<24) + (p[1]<<16) + (p[2]<<8) + p[3]; }
+ 
+ #define stbtt_tag4(p,c0,c1,c2,c3) ((p)[0] == (c0) && (p)[1] == (c1) && (p)[2] == (c2) && (p)[3] == (c3))
+ #define stbtt_tag(p,str)           stbtt_tag4(p,str[0],str[1],str[2],str[3])
+ 
+-static int stbtt__isfont(const stbtt_uint8 *font)
++static int stbtt__isfont(stbtt_uint8 *font)
+ {
+    // check the version number
+    if (stbtt_tag4(font, '1',0,0,0))  return 1; // TrueType 1
+    if (stbtt_tag(font, "typ1"))   return 1; // TrueType with type 1 font -- we don't support this!
+    if (stbtt_tag(font, "OTTO"))   return 1; // OpenType with CFF
+    if (stbtt_tag4(font, 0,1,0,0)) return 1; // OpenType 1.0
++   if (stbtt_tag(font, "true"))   return 1; // Apple specification for TrueType fonts
+    return 0;
+ }
+ 
+@@ -998,7 +1316,7 @@ static stbtt_uint32 stbtt__find_table(stbtt_uint8 *data, stbtt_uint32 fontstart,
+    return 0;
+ }
+ 
+-STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *font_collection, int index)
++static int stbtt_GetFontOffsetForIndex_internal(unsigned char *font_collection, int index)
+ {
+    // if it's just a font, there's only one valid index
+    if (stbtt__isfont(font_collection))
+@@ -1017,14 +1335,59 @@ STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *font_collection,
+    return -1;
+ }
+ 
+-STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data2, int fontstart)
++static int stbtt_GetNumberOfFonts_internal(unsigned char *font_collection)
++{
++   // if it's just a font, there's only one valid font
++   if (stbtt__isfont(font_collection))
++      return 1;
++
++   // check if it's a TTC
++   if (stbtt_tag(font_collection, "ttcf")) {
++      // version 1?
++      if (ttULONG(font_collection+4) == 0x00010000 || ttULONG(font_collection+4) == 0x00020000) {
++         return ttLONG(font_collection+8);
++      }
++   }
++   return 0;
++}
++
++static stbtt__buf stbtt__get_subrs(stbtt__buf cff, stbtt__buf fontdict)
++{
++   stbtt_uint32 subrsoff = 0, private_loc[2] = { 0, 0 };
++   stbtt__buf pdict;
++   stbtt__dict_get_ints(&fontdict, 18, 2, private_loc);
++   if (!private_loc[1] || !private_loc[0]) return stbtt__new_buf(NULL, 0);
++   pdict = stbtt__buf_range(&cff, private_loc[1], private_loc[0]);
++   stbtt__dict_get_ints(&pdict, 19, 1, &subrsoff);
++   if (!subrsoff) return stbtt__new_buf(NULL, 0);
++   stbtt__buf_seek(&cff, private_loc[1]+subrsoff);
++   return stbtt__cff_get_index(&cff);
++}
++
++// since most people won't use this, find this table the first time it's needed
++static int stbtt__get_svg(stbtt_fontinfo *info)
++{
++   stbtt_uint32 t;
++   if (info->svg < 0) {
++      t = stbtt__find_table(info->data, info->fontstart, "SVG ");
++      if (t) {
++         stbtt_uint32 offset = ttULONG(info->data + t + 2);
++         info->svg = t + offset;
++      } else {
++         info->svg = 0;
++      }
++   }
++   return info->svg;
++}
++
++static int stbtt_InitFont_internal(stbtt_fontinfo *info, unsigned char *data, int fontstart)
+ {
+-   stbtt_uint8 *data = (stbtt_uint8 *) data2;
+    stbtt_uint32 cmap, t;
+    stbtt_int32 i,numTables;
+ 
+    info->data = data;
+    info->fontstart = fontstart;
++   info->cff = stbtt__new_buf(NULL, 0);
+ 
+    cmap = stbtt__find_table(data, fontstart, "cmap");       // required
+    info->loca = stbtt__find_table(data, fontstart, "loca"); // required
+@@ -1033,8 +1396,62 @@ STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data2, i
+    info->hhea = stbtt__find_table(data, fontstart, "hhea"); // required
+    info->hmtx = stbtt__find_table(data, fontstart, "hmtx"); // required
+    info->kern = stbtt__find_table(data, fontstart, "kern"); // not required
+-   if (!cmap || !info->loca || !info->head || !info->glyf || !info->hhea || !info->hmtx)
++   info->gpos = stbtt__find_table(data, fontstart, "GPOS"); // not required
++
++   if (!cmap || !info->head || !info->hhea || !info->hmtx)
+       return 0;
++   if (info->glyf) {
++      // required for truetype
++      if (!info->loca) return 0;
++   } else {
++      // initialization for CFF / Type2 fonts (OTF)
++      stbtt__buf b, topdict, topdictidx;
++      stbtt_uint32 cstype = 2, charstrings = 0, fdarrayoff = 0, fdselectoff = 0;
++      stbtt_uint32 cff;
++
++      cff = stbtt__find_table(data, fontstart, "CFF ");
++      if (!cff) return 0;
++
++      info->fontdicts = stbtt__new_buf(NULL, 0);
++      info->fdselect = stbtt__new_buf(NULL, 0);
++
++      // @TODO this should use size from table (not 512MB)
++      info->cff = stbtt__new_buf(data+cff, 512*1024*1024);
++      b = info->cff;
++
++      // read the header
++      stbtt__buf_skip(&b, 2);
++      stbtt__buf_seek(&b, stbtt__buf_get8(&b)); // hdrsize
++
++      // @TODO the name INDEX could list multiple fonts,
++      // but we just use the first one.
++      stbtt__cff_get_index(&b);  // name INDEX
++      topdictidx = stbtt__cff_get_index(&b);
++      topdict = stbtt__cff_index_get(topdictidx, 0);
++      stbtt__cff_get_index(&b);  // string INDEX
++      info->gsubrs = stbtt__cff_get_index(&b);
++
++      stbtt__dict_get_ints(&topdict, 17, 1, &charstrings);
++      stbtt__dict_get_ints(&topdict, 0x100 | 6, 1, &cstype);
++      stbtt__dict_get_ints(&topdict, 0x100 | 36, 1, &fdarrayoff);
++      stbtt__dict_get_ints(&topdict, 0x100 | 37, 1, &fdselectoff);
++      info->subrs = stbtt__get_subrs(b, topdict);
++
++      // we only support Type 2 charstrings
++      if (cstype != 2) return 0;
++      if (charstrings == 0) return 0;
++
++      if (fdarrayoff) {
++         // looks like a CID font
++         if (!fdselectoff) return 0;
++         stbtt__buf_seek(&b, fdarrayoff);
++         info->fontdicts = stbtt__cff_get_index(&b);
++         info->fdselect = stbtt__buf_range(&b, fdselectoff, b.size-fdselectoff);
++      }
++
++      stbtt__buf_seek(&b, charstrings);
++      info->charstrings = stbtt__cff_get_index(&b);
++   }
+ 
+    t = stbtt__find_table(data, fontstart, "maxp");
+    if (t)
+@@ -1042,6 +1459,8 @@ STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data2, i
+    else
+       info->numGlyphs = 0xffff;
+ 
++   info->svg = -1;
++
+    // find a cmap encoding table we understand *now* to avoid searching
+    // later. (todo: could make this installable)
+    // the same regardless of glyph.
+@@ -1125,12 +1544,12 @@ STBTT_DEF int stbtt_FindGlyphIndex(const stbtt_fontinfo *info, int unicode_codep
+       search += 2;
+ 
+       {
+-         stbtt_uint16 offset, start;
++         stbtt_uint16 offset, start, last;
+          stbtt_uint16 item = (stbtt_uint16) ((search - endCount) >> 1);
+ 
+-         STBTT_assert(unicode_codepoint <= ttUSHORT(data + endCount + 2*item));
+          start = ttUSHORT(data + index_map + 14 + segcount*2 + 2 + 2*item);
+-         if (unicode_codepoint < start)
++         last = ttUSHORT(data + endCount + 2*item);
++         if (unicode_codepoint < start || unicode_codepoint > last)
+             return 0;
+ 
+          offset = ttUSHORT(data + index_map + 14 + segcount*6 + 2 + 2*item);
+@@ -1185,6 +1604,8 @@ static int stbtt__GetGlyfOffset(const stbtt_fontinfo *info, int glyph_index)
+ {
+    int g1,g2;
+ 
++   STBTT_assert(!info->cff.size);
++
+    if (glyph_index >= info->numGlyphs) return -1; // glyph index out of range
+    if (info->indexToLocFormat >= 2)    return -1; // unknown index->glyph map format
+ 
+@@ -1199,15 +1620,21 @@ static int stbtt__GetGlyfOffset(const stbtt_fontinfo *info, int glyph_index)
+    return g1==g2 ? -1 : g1; // if length is 0, return -1
+ }
+ 
++static int stbtt__GetGlyphInfoT2(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1);
++
+ STBTT_DEF int stbtt_GetGlyphBox(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1)
+ {
+-   int g = stbtt__GetGlyfOffset(info, glyph_index);
+-   if (g < 0) return 0;
++   if (info->cff.size) {
++      stbtt__GetGlyphInfoT2(info, glyph_index, x0, y0, x1, y1);
++   } else {
++      int g = stbtt__GetGlyfOffset(info, glyph_index);
++      if (g < 0) return 0;
+ 
+-   if (x0) *x0 = ttSHORT(info->data + g + 2);
+-   if (y0) *y0 = ttSHORT(info->data + g + 4);
+-   if (x1) *x1 = ttSHORT(info->data + g + 6);
+-   if (y1) *y1 = ttSHORT(info->data + g + 8);
++      if (x0) *x0 = ttSHORT(info->data + g + 2);
++      if (y0) *y0 = ttSHORT(info->data + g + 4);
++      if (x1) *x1 = ttSHORT(info->data + g + 6);
++      if (y1) *y1 = ttSHORT(info->data + g + 8);
++   }
+    return 1;
+ }
+ 
+@@ -1219,7 +1646,10 @@ STBTT_DEF int stbtt_GetCodepointBox(const stbtt_fontinfo *info, int codepoint, i
+ STBTT_DEF int stbtt_IsGlyphEmpty(const stbtt_fontinfo *info, int glyph_index)
+ {
+    stbtt_int16 numberOfContours;
+-   int g = stbtt__GetGlyfOffset(info, glyph_index);
++   int g;
++   if (info->cff.size)
++      return stbtt__GetGlyphInfoT2(info, glyph_index, NULL, NULL, NULL, NULL) == 0;
++   g = stbtt__GetGlyfOffset(info, glyph_index);
+    if (g < 0) return 1;
+    numberOfContours = ttSHORT(info->data + g);
+    return numberOfContours == 0;
+@@ -1241,7 +1671,7 @@ static int stbtt__close_shape(stbtt_vertex *vertices, int num_vertices, int was_
+    return num_vertices;
+ }
+ 
+-STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
++static int stbtt__GetGlyphShapeTT(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
+ {
+    stbtt_int16 numberOfContours;
+    stbtt_uint8 *endPtsOfContours;
+@@ -1337,7 +1767,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+             if (i != 0)
+                num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
+ 
+-            // now start the new one               
++            // now start the new one
+             start_off = !(flags & 1);
+             if (start_off) {
+                // if we start off with an off-curve point, then when we need to find a point on the curve
+@@ -1379,7 +1809,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+          }
+       }
+       num_vertices = stbtt__close_shape(vertices, num_vertices, was_off, start_off, sx,sy,scx,scy,cx,cy);
+-   } else if (numberOfContours == -1) {
++   } else if (numberOfContours < 0) {
+       // Compound shapes.
+       int more = 1;
+       stbtt_uint8 *comp = data + g + 10;
+@@ -1390,7 +1820,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+          int comp_num_verts = 0, i;
+          stbtt_vertex *comp_verts = 0, *tmp = 0;
+          float mtx[6] = {1,0,0,1,0,0}, m, n;
+-         
++
+          flags = ttSHORT(comp); comp+=2;
+          gidx = ttSHORT(comp); comp+=2;
+ 
+@@ -1420,7 +1850,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+             mtx[2] = ttSHORT(comp)/16384.0f; comp+=2;
+             mtx[3] = ttSHORT(comp)/16384.0f; comp+=2;
+          }
+-         
++
+          // Find transformation scales.
+          m = (float) STBTT_sqrt(mtx[0]*mtx[0] + mtx[1]*mtx[1]);
+          n = (float) STBTT_sqrt(mtx[2]*mtx[2] + mtx[3]*mtx[3]);
+@@ -1446,7 +1876,7 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+                if (comp_verts) STBTT_free(comp_verts, info->userdata);
+                return 0;
+             }
+-            if (num_vertices > 0) STBTT_memcpy(tmp, vertices, num_vertices*sizeof(stbtt_vertex));
++            if (num_vertices > 0 && vertices) STBTT_memcpy(tmp, vertices, num_vertices*sizeof(stbtt_vertex));
+             STBTT_memcpy(tmp+num_vertices, comp_verts, comp_num_verts*sizeof(stbtt_vertex));
+             if (vertices) STBTT_free(vertices, info->userdata);
+             vertices = tmp;
+@@ -1456,9 +1886,6 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+          // More components ?
+          more = flags & (1<<5);
+       }
+-   } else if (numberOfContours < 0) {
+-      // @TODO other compound variations?
+-      STBTT_assert(0);
+    } else {
+       // numberOfCounters == 0, do nothing
+    }
+@@ -1467,6 +1894,414 @@ STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, s
+    return num_vertices;
+ }
+ 
++typedef struct
++{
++   int bounds;
++   int started;
++   float first_x, first_y;
++   float x, y;
++   stbtt_int32 min_x, max_x, min_y, max_y;
++
++   stbtt_vertex *pvertices;
++   int num_vertices;
++} stbtt__csctx;
++
++#define STBTT__CSCTX_INIT(bounds) {bounds,0, 0,0, 0,0, 0,0,0,0, NULL, 0}
++
++static void stbtt__track_vertex(stbtt__csctx *c, stbtt_int32 x, stbtt_int32 y)
++{
++   if (x > c->max_x || !c->started) c->max_x = x;
++   if (y > c->max_y || !c->started) c->max_y = y;
++   if (x < c->min_x || !c->started) c->min_x = x;
++   if (y < c->min_y || !c->started) c->min_y = y;
++   c->started = 1;
++}
++
++static void stbtt__csctx_v(stbtt__csctx *c, stbtt_uint8 type, stbtt_int32 x, stbtt_int32 y, stbtt_int32 cx, stbtt_int32 cy, stbtt_int32 cx1, stbtt_int32 cy1)
++{
++   if (c->bounds) {
++      stbtt__track_vertex(c, x, y);
++      if (type == STBTT_vcubic) {
++         stbtt__track_vertex(c, cx, cy);
++         stbtt__track_vertex(c, cx1, cy1);
++      }
++   } else {
++      stbtt_setvertex(&c->pvertices[c->num_vertices], type, x, y, cx, cy);
++      c->pvertices[c->num_vertices].cx1 = (stbtt_int16) cx1;
++      c->pvertices[c->num_vertices].cy1 = (stbtt_int16) cy1;
++   }
++   c->num_vertices++;
++}
++
++static void stbtt__csctx_close_shape(stbtt__csctx *ctx)
++{
++   if (ctx->first_x != ctx->x || ctx->first_y != ctx->y)
++      stbtt__csctx_v(ctx, STBTT_vline, (int)ctx->first_x, (int)ctx->first_y, 0, 0, 0, 0);
++}
++
++static void stbtt__csctx_rmove_to(stbtt__csctx *ctx, float dx, float dy)
++{
++   stbtt__csctx_close_shape(ctx);
++   ctx->first_x = ctx->x = ctx->x + dx;
++   ctx->first_y = ctx->y = ctx->y + dy;
++   stbtt__csctx_v(ctx, STBTT_vmove, (int)ctx->x, (int)ctx->y, 0, 0, 0, 0);
++}
++
++static void stbtt__csctx_rline_to(stbtt__csctx *ctx, float dx, float dy)
++{
++   ctx->x += dx;
++   ctx->y += dy;
++   stbtt__csctx_v(ctx, STBTT_vline, (int)ctx->x, (int)ctx->y, 0, 0, 0, 0);
++}
++
++static void stbtt__csctx_rccurve_to(stbtt__csctx *ctx, float dx1, float dy1, float dx2, float dy2, float dx3, float dy3)
++{
++   float cx1 = ctx->x + dx1;
++   float cy1 = ctx->y + dy1;
++   float cx2 = cx1 + dx2;
++   float cy2 = cy1 + dy2;
++   ctx->x = cx2 + dx3;
++   ctx->y = cy2 + dy3;
++   stbtt__csctx_v(ctx, STBTT_vcubic, (int)ctx->x, (int)ctx->y, (int)cx1, (int)cy1, (int)cx2, (int)cy2);
++}
++
++static stbtt__buf stbtt__get_subr(stbtt__buf idx, int n)
++{
++   int count = stbtt__cff_index_count(&idx);
++   int bias = 107;
++   if (count >= 33900)
++      bias = 32768;
++   else if (count >= 1240)
++      bias = 1131;
++   n += bias;
++   if (n < 0 || n >= count)
++      return stbtt__new_buf(NULL, 0);
++   return stbtt__cff_index_get(idx, n);
++}
++
++static stbtt__buf stbtt__cid_get_glyph_subrs(const stbtt_fontinfo *info, int glyph_index)
++{
++   stbtt__buf fdselect = info->fdselect;
++   int nranges, start, end, v, fmt, fdselector = -1, i;
++
++   stbtt__buf_seek(&fdselect, 0);
++   fmt = stbtt__buf_get8(&fdselect);
++   if (fmt == 0) {
++      // untested
++      stbtt__buf_skip(&fdselect, glyph_index);
++      fdselector = stbtt__buf_get8(&fdselect);
++   } else if (fmt == 3) {
++      nranges = stbtt__buf_get16(&fdselect);
++      start = stbtt__buf_get16(&fdselect);
++      for (i = 0; i < nranges; i++) {
++         v = stbtt__buf_get8(&fdselect);
++         end = stbtt__buf_get16(&fdselect);
++         if (glyph_index >= start && glyph_index < end) {
++            fdselector = v;
++            break;
++         }
++         start = end;
++      }
++   }
++   if (fdselector == -1) stbtt__new_buf(NULL, 0);
++   return stbtt__get_subrs(info->cff, stbtt__cff_index_get(info->fontdicts, fdselector));
++}
++
++static int stbtt__run_charstring(const stbtt_fontinfo *info, int glyph_index, stbtt__csctx *c)
++{
++   int in_header = 1, maskbits = 0, subr_stack_height = 0, sp = 0, v, i, b0;
++   int has_subrs = 0, clear_stack;
++   float s[48];
++   stbtt__buf subr_stack[10], subrs = info->subrs, b;
++   float f;
++
++#define STBTT__CSERR(s) (0)
++
++   // this currently ignores the initial width value, which isn't needed if we have hmtx
++   b = stbtt__cff_index_get(info->charstrings, glyph_index);
++   while (b.cursor < b.size) {
++      i = 0;
++      clear_stack = 1;
++      b0 = stbtt__buf_get8(&b);
++      switch (b0) {
++      // @TODO implement hinting
++      case 0x13: // hintmask
++      case 0x14: // cntrmask
++         if (in_header)
++            maskbits += (sp / 2); // implicit "vstem"
++         in_header = 0;
++         stbtt__buf_skip(&b, (maskbits + 7) / 8);
++         break;
++
++      case 0x01: // hstem
++      case 0x03: // vstem
++      case 0x12: // hstemhm
++      case 0x17: // vstemhm
++         maskbits += (sp / 2);
++         break;
++
++      case 0x15: // rmoveto
++         in_header = 0;
++         if (sp < 2) return STBTT__CSERR("rmoveto stack");
++         stbtt__csctx_rmove_to(c, s[sp-2], s[sp-1]);
++         break;
++      case 0x04: // vmoveto
++         in_header = 0;
++         if (sp < 1) return STBTT__CSERR("vmoveto stack");
++         stbtt__csctx_rmove_to(c, 0, s[sp-1]);
++         break;
++      case 0x16: // hmoveto
++         in_header = 0;
++         if (sp < 1) return STBTT__CSERR("hmoveto stack");
++         stbtt__csctx_rmove_to(c, s[sp-1], 0);
++         break;
++
++      case 0x05: // rlineto
++         if (sp < 2) return STBTT__CSERR("rlineto stack");
++         for (; i + 1 < sp; i += 2)
++            stbtt__csctx_rline_to(c, s[i], s[i+1]);
++         break;
++
++      // hlineto/vlineto and vhcurveto/hvcurveto alternate horizontal and vertical
++      // starting from a different place.
++
++      case 0x07: // vlineto
++         if (sp < 1) return STBTT__CSERR("vlineto stack");
++         goto vlineto;
++      case 0x06: // hlineto
++         if (sp < 1) return STBTT__CSERR("hlineto stack");
++         for (;;) {
++            if (i >= sp) break;
++            stbtt__csctx_rline_to(c, s[i], 0);
++            i++;
++      vlineto:
++            if (i >= sp) break;
++            stbtt__csctx_rline_to(c, 0, s[i]);
++            i++;
++         }
++         break;
++
++      case 0x1F: // hvcurveto
++         if (sp < 4) return STBTT__CSERR("hvcurveto stack");
++         goto hvcurveto;
++      case 0x1E: // vhcurveto
++         if (sp < 4) return STBTT__CSERR("vhcurveto stack");
++         for (;;) {
++            if (i + 3 >= sp) break;
++            stbtt__csctx_rccurve_to(c, 0, s[i], s[i+1], s[i+2], s[i+3], (sp - i == 5) ? s[i + 4] : 0.0f);
++            i += 4;
++      hvcurveto:
++            if (i + 3 >= sp) break;
++            stbtt__csctx_rccurve_to(c, s[i], 0, s[i+1], s[i+2], (sp - i == 5) ? s[i+4] : 0.0f, s[i+3]);
++            i += 4;
++         }
++         break;
++
++      case 0x08: // rrcurveto
++         if (sp < 6) return STBTT__CSERR("rcurveline stack");
++         for (; i + 5 < sp; i += 6)
++            stbtt__csctx_rccurve_to(c, s[i], s[i+1], s[i+2], s[i+3], s[i+4], s[i+5]);
++         break;
++
++      case 0x18: // rcurveline
++         if (sp < 8) return STBTT__CSERR("rcurveline stack");
++         for (; i + 5 < sp - 2; i += 6)
++            stbtt__csctx_rccurve_to(c, s[i], s[i+1], s[i+2], s[i+3], s[i+4], s[i+5]);
++         if (i + 1 >= sp) return STBTT__CSERR("rcurveline stack");
++         stbtt__csctx_rline_to(c, s[i], s[i+1]);
++         break;
++
++      case 0x19: // rlinecurve
++         if (sp < 8) return STBTT__CSERR("rlinecurve stack");
++         for (; i + 1 < sp - 6; i += 2)
++            stbtt__csctx_rline_to(c, s[i], s[i+1]);
++         if (i + 5 >= sp) return STBTT__CSERR("rlinecurve stack");
++         stbtt__csctx_rccurve_to(c, s[i], s[i+1], s[i+2], s[i+3], s[i+4], s[i+5]);
++         break;
++
++      case 0x1A: // vvcurveto
++      case 0x1B: // hhcurveto
++         if (sp < 4) return STBTT__CSERR("(vv|hh)curveto stack");
++         f = 0.0;
++         if (sp & 1) { f = s[i]; i++; }
++         for (; i + 3 < sp; i += 4) {
++            if (b0 == 0x1B)
++               stbtt__csctx_rccurve_to(c, s[i], f, s[i+1], s[i+2], s[i+3], 0.0);
++            else
++               stbtt__csctx_rccurve_to(c, f, s[i], s[i+1], s[i+2], 0.0, s[i+3]);
++            f = 0.0;
++         }
++         break;
++
++      case 0x0A: // callsubr
++         if (!has_subrs) {
++            if (info->fdselect.size)
++               subrs = stbtt__cid_get_glyph_subrs(info, glyph_index);
++            has_subrs = 1;
++         }
++         // FALLTHROUGH
++      case 0x1D: // callgsubr
++         if (sp < 1) return STBTT__CSERR("call(g|)subr stack");
++         v = (int) s[--sp];
++         if (subr_stack_height >= 10) return STBTT__CSERR("recursion limit");
++         subr_stack[subr_stack_height++] = b;
++         b = stbtt__get_subr(b0 == 0x0A ? subrs : info->gsubrs, v);
++         if (b.size == 0) return STBTT__CSERR("subr not found");
++         b.cursor = 0;
++         clear_stack = 0;
++         break;
++
++      case 0x0B: // return
++         if (subr_stack_height <= 0) return STBTT__CSERR("return outside subr");
++         b = subr_stack[--subr_stack_height];
++         clear_stack = 0;
++         break;
++
++      case 0x0E: // endchar
++         stbtt__csctx_close_shape(c);
++         return 1;
++
++      case 0x0C: { // two-byte escape
++         float dx1, dx2, dx3, dx4, dx5, dx6, dy1, dy2, dy3, dy4, dy5, dy6;
++         float dx, dy;
++         int b1 = stbtt__buf_get8(&b);
++         switch (b1) {
++         // @TODO These "flex" implementations ignore the flex-depth and resolution,
++         // and always draw beziers.
++         case 0x22: // hflex
++            if (sp < 7) return STBTT__CSERR("hflex stack");
++            dx1 = s[0];
++            dx2 = s[1];
++            dy2 = s[2];
++            dx3 = s[3];
++            dx4 = s[4];
++            dx5 = s[5];
++            dx6 = s[6];
++            stbtt__csctx_rccurve_to(c, dx1, 0, dx2, dy2, dx3, 0);
++            stbtt__csctx_rccurve_to(c, dx4, 0, dx5, -dy2, dx6, 0);
++            break;
++
++         case 0x23: // flex
++            if (sp < 13) return STBTT__CSERR("flex stack");
++            dx1 = s[0];
++            dy1 = s[1];
++            dx2 = s[2];
++            dy2 = s[3];
++            dx3 = s[4];
++            dy3 = s[5];
++            dx4 = s[6];
++            dy4 = s[7];
++            dx5 = s[8];
++            dy5 = s[9];
++            dx6 = s[10];
++            dy6 = s[11];
++            //fd is s[12]
++            stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, dy3);
++            stbtt__csctx_rccurve_to(c, dx4, dy4, dx5, dy5, dx6, dy6);
++            break;
++
++         case 0x24: // hflex1
++            if (sp < 9) return STBTT__CSERR("hflex1 stack");
++            dx1 = s[0];
++            dy1 = s[1];
++            dx2 = s[2];
++            dy2 = s[3];
++            dx3 = s[4];
++            dx4 = s[5];
++            dx5 = s[6];
++            dy5 = s[7];
++            dx6 = s[8];
++            stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, 0);
++            stbtt__csctx_rccurve_to(c, dx4, 0, dx5, dy5, dx6, -(dy1+dy2+dy5));
++            break;
++
++         case 0x25: // flex1
++            if (sp < 11) return STBTT__CSERR("flex1 stack");
++            dx1 = s[0];
++            dy1 = s[1];
++            dx2 = s[2];
++            dy2 = s[3];
++            dx3 = s[4];
++            dy3 = s[5];
++            dx4 = s[6];
++            dy4 = s[7];
++            dx5 = s[8];
++            dy5 = s[9];
++            dx6 = dy6 = s[10];
++            dx = dx1+dx2+dx3+dx4+dx5;
++            dy = dy1+dy2+dy3+dy4+dy5;
++            if (STBTT_fabs(dx) > STBTT_fabs(dy))
++               dy6 = -dy;
++            else
++               dx6 = -dx;
++            stbtt__csctx_rccurve_to(c, dx1, dy1, dx2, dy2, dx3, dy3);
++            stbtt__csctx_rccurve_to(c, dx4, dy4, dx5, dy5, dx6, dy6);
++            break;
++
++         default:
++            return STBTT__CSERR("unimplemented");
++         }
++      } break;
++
++      default:
++         if (b0 != 255 && b0 != 28 && b0 < 32)
++            return STBTT__CSERR("reserved operator");
++
++         // push immediate
++         if (b0 == 255) {
++            f = (float)(stbtt_int32)stbtt__buf_get32(&b) / 0x10000;
++         } else {
++            stbtt__buf_skip(&b, -1);
++            f = (float)(stbtt_int16)stbtt__cff_int(&b);
++         }
++         if (sp >= 48) return STBTT__CSERR("push stack overflow");
++         s[sp++] = f;
++         clear_stack = 0;
++         break;
++      }
++      if (clear_stack) sp = 0;
++   }
++   return STBTT__CSERR("no endchar");
++
++#undef STBTT__CSERR
++}
++
++static int stbtt__GetGlyphShapeT2(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
++{
++   // runs the charstring twice, once to count and once to output (to avoid realloc)
++   stbtt__csctx count_ctx = STBTT__CSCTX_INIT(1);
++   stbtt__csctx output_ctx = STBTT__CSCTX_INIT(0);
++   if (stbtt__run_charstring(info, glyph_index, &count_ctx)) {
++      *pvertices = (stbtt_vertex*)STBTT_malloc(count_ctx.num_vertices*sizeof(stbtt_vertex), info->userdata);
++      output_ctx.pvertices = *pvertices;
++      if (stbtt__run_charstring(info, glyph_index, &output_ctx)) {
++         STBTT_assert(output_ctx.num_vertices == count_ctx.num_vertices);
++         return output_ctx.num_vertices;
++      }
++   }
++   *pvertices = NULL;
++   return 0;
++}
++
++static int stbtt__GetGlyphInfoT2(const stbtt_fontinfo *info, int glyph_index, int *x0, int *y0, int *x1, int *y1)
++{
++   stbtt__csctx c = STBTT__CSCTX_INIT(1);
++   int r = stbtt__run_charstring(info, glyph_index, &c);
++   if (x0)  *x0 = r ? c.min_x : 0;
++   if (y0)  *y0 = r ? c.min_y : 0;
++   if (x1)  *x1 = r ? c.max_x : 0;
++   if (y1)  *y1 = r ? c.max_y : 0;
++   return r ? c.num_vertices : 0;
++}
++
++STBTT_DEF int stbtt_GetGlyphShape(const stbtt_fontinfo *info, int glyph_index, stbtt_vertex **pvertices)
++{
++   if (!info->cff.size)
++      return stbtt__GetGlyphShapeTT(info, glyph_index, pvertices);
++   else
++      return stbtt__GetGlyphShapeT2(info, glyph_index, pvertices);
++}
++
+ STBTT_DEF void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info, int glyph_index, int *advanceWidth, int *leftSideBearing)
+ {
+    stbtt_uint16 numOfLongHorMetrics = ttUSHORT(info->data+info->hhea + 34);
+@@ -1479,7 +2314,49 @@ STBTT_DEF void stbtt_GetGlyphHMetrics(const stbtt_fontinfo *info, int glyph_inde
+    }
+ }
+ 
+-STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
++STBTT_DEF int  stbtt_GetKerningTableLength(const stbtt_fontinfo *info)
++{
++   stbtt_uint8 *data = info->data + info->kern;
++
++   // we only look at the first table. it must be 'horizontal' and format 0.
++   if (!info->kern)
++      return 0;
++   if (ttUSHORT(data+2) < 1) // number of tables, need at least 1
++      return 0;
++   if (ttUSHORT(data+8) != 1) // horizontal flag must be set in format
++      return 0;
++
++   return ttUSHORT(data+10);
++}
++
++STBTT_DEF int stbtt_GetKerningTable(const stbtt_fontinfo *info, stbtt_kerningentry* table, int table_length)
++{
++   stbtt_uint8 *data = info->data + info->kern;
++   int k, length;
++
++   // we only look at the first table. it must be 'horizontal' and format 0.
++   if (!info->kern)
++      return 0;
++   if (ttUSHORT(data+2) < 1) // number of tables, need at least 1
++      return 0;
++   if (ttUSHORT(data+8) != 1) // horizontal flag must be set in format
++      return 0;
++
++   length = ttUSHORT(data+10);
++   if (table_length < length)
++      length = table_length;
++
++   for (k = 0; k < length; k++)
++   {
++      table[k].glyph1 = ttUSHORT(data+18+(k*6));
++      table[k].glyph2 = ttUSHORT(data+20+(k*6));
++      table[k].advance = ttSHORT(data+22+(k*6));
++   }
++
++   return length;
++}
++
++static int stbtt__GetGlyphKernInfoAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
+ {
+    stbtt_uint8 *data = info->data + info->kern;
+    stbtt_uint32 needle, straw;
+@@ -1509,9 +2386,242 @@ STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int glyph1,
+    return 0;
+ }
+ 
++static stbtt_int32 stbtt__GetCoverageIndex(stbtt_uint8 *coverageTable, int glyph)
++{
++   stbtt_uint16 coverageFormat = ttUSHORT(coverageTable);
++   switch (coverageFormat) {
++      case 1: {
++         stbtt_uint16 glyphCount = ttUSHORT(coverageTable + 2);
++
++         // Binary search.
++         stbtt_int32 l=0, r=glyphCount-1, m;
++         int straw, needle=glyph;
++         while (l <= r) {
++            stbtt_uint8 *glyphArray = coverageTable + 4;
++            stbtt_uint16 glyphID;
++            m = (l + r) >> 1;
++            glyphID = ttUSHORT(glyphArray + 2 * m);
++            straw = glyphID;
++            if (needle < straw)
++               r = m - 1;
++            else if (needle > straw)
++               l = m + 1;
++            else {
++               return m;
++            }
++         }
++         break;
++      }
++
++      case 2: {
++         stbtt_uint16 rangeCount = ttUSHORT(coverageTable + 2);
++         stbtt_uint8 *rangeArray = coverageTable + 4;
++
++         // Binary search.
++         stbtt_int32 l=0, r=rangeCount-1, m;
++         int strawStart, strawEnd, needle=glyph;
++         while (l <= r) {
++            stbtt_uint8 *rangeRecord;
++            m = (l + r) >> 1;
++            rangeRecord = rangeArray + 6 * m;
++            strawStart = ttUSHORT(rangeRecord);
++            strawEnd = ttUSHORT(rangeRecord + 2);
++            if (needle < strawStart)
++               r = m - 1;
++            else if (needle > strawEnd)
++               l = m + 1;
++            else {
++               stbtt_uint16 startCoverageIndex = ttUSHORT(rangeRecord + 4);
++               return startCoverageIndex + glyph - strawStart;
++            }
++         }
++         break;
++      }
++
++      default: return -1; // unsupported
++   }
++
++   return -1;
++}
++
++static stbtt_int32  stbtt__GetGlyphClass(stbtt_uint8 *classDefTable, int glyph)
++{
++   stbtt_uint16 classDefFormat = ttUSHORT(classDefTable);
++   switch (classDefFormat)
++   {
++      case 1: {
++         stbtt_uint16 startGlyphID = ttUSHORT(classDefTable + 2);
++         stbtt_uint16 glyphCount = ttUSHORT(classDefTable + 4);
++         stbtt_uint8 *classDef1ValueArray = classDefTable + 6;
++
++         if (glyph >= startGlyphID && glyph < startGlyphID + glyphCount)
++            return (stbtt_int32)ttUSHORT(classDef1ValueArray + 2 * (glyph - startGlyphID));
++         break;
++      }
++
++      case 2: {
++         stbtt_uint16 classRangeCount = ttUSHORT(classDefTable + 2);
++         stbtt_uint8 *classRangeRecords = classDefTable + 4;
++
++         // Binary search.
++         stbtt_int32 l=0, r=classRangeCount-1, m;
++         int strawStart, strawEnd, needle=glyph;
++         while (l <= r) {
++            stbtt_uint8 *classRangeRecord;
++            m = (l + r) >> 1;
++            classRangeRecord = classRangeRecords + 6 * m;
++            strawStart = ttUSHORT(classRangeRecord);
++            strawEnd = ttUSHORT(classRangeRecord + 2);
++            if (needle < strawStart)
++               r = m - 1;
++            else if (needle > strawEnd)
++               l = m + 1;
++            else
++               return (stbtt_int32)ttUSHORT(classRangeRecord + 4);
++         }
++         break;
++      }
++
++      default:
++         return -1; // Unsupported definition type, return an error.
++   }
++
++   // "All glyphs not assigned to a class fall into class 0". (OpenType spec)
++   return 0;
++}
++
++// Define to STBTT_assert(x) if you want to break on unimplemented formats.
++#define STBTT_GPOS_TODO_assert(x)
++
++static stbtt_int32 stbtt__GetGlyphGPOSInfoAdvance(const stbtt_fontinfo *info, int glyph1, int glyph2)
++{
++   stbtt_uint16 lookupListOffset;
++   stbtt_uint8 *lookupList;
++   stbtt_uint16 lookupCount;
++   stbtt_uint8 *data;
++   stbtt_int32 i, sti;
++
++   if (!info->gpos) return 0;
++
++   data = info->data + info->gpos;
++
++   if (ttUSHORT(data+0) != 1) return 0; // Major version 1
++   if (ttUSHORT(data+2) != 0) return 0; // Minor version 0
++
++   lookupListOffset = ttUSHORT(data+8);
++   lookupList = data + lookupListOffset;
++   lookupCount = ttUSHORT(lookupList);
++
++   for (i=0; i<lookupCount; ++i) {
++      stbtt_uint16 lookupOffset = ttUSHORT(lookupList + 2 + 2 * i);
++      stbtt_uint8 *lookupTable = lookupList + lookupOffset;
++
++      stbtt_uint16 lookupType = ttUSHORT(lookupTable);
++      stbtt_uint16 subTableCount = ttUSHORT(lookupTable + 4);
++      stbtt_uint8 *subTableOffsets = lookupTable + 6;
++      if (lookupType != 2) // Pair Adjustment Positioning Subtable
++         continue;
++
++      for (sti=0; sti<subTableCount; sti++) {
++         stbtt_uint16 subtableOffset = ttUSHORT(subTableOffsets + 2 * sti);
++         stbtt_uint8 *table = lookupTable + subtableOffset;
++         stbtt_uint16 posFormat = ttUSHORT(table);
++         stbtt_uint16 coverageOffset = ttUSHORT(table + 2);
++         stbtt_int32 coverageIndex = stbtt__GetCoverageIndex(table + coverageOffset, glyph1);
++         if (coverageIndex == -1) continue;
++
++         switch (posFormat) {
++            case 1: {
++               stbtt_int32 l, r, m;
++               int straw, needle;
++               stbtt_uint16 valueFormat1 = ttUSHORT(table + 4);
++               stbtt_uint16 valueFormat2 = ttUSHORT(table + 6);
++               if (valueFormat1 == 4 && valueFormat2 == 0) { // Support more formats?
++                  stbtt_int32 valueRecordPairSizeInBytes = 2;
++                  stbtt_uint16 pairSetCount = ttUSHORT(table + 8);
++                  stbtt_uint16 pairPosOffset = ttUSHORT(table + 10 + 2 * coverageIndex);
++                  stbtt_uint8 *pairValueTable = table + pairPosOffset;
++                  stbtt_uint16 pairValueCount = ttUSHORT(pairValueTable);
++                  stbtt_uint8 *pairValueArray = pairValueTable + 2;
++
++                  if (coverageIndex >= pairSetCount) return 0;
++
++                  needle=glyph2;
++                  r=pairValueCount-1;
++                  l=0;
++
++                  // Binary search.
++                  while (l <= r) {
++                     stbtt_uint16 secondGlyph;
++                     stbtt_uint8 *pairValue;
++                     m = (l + r) >> 1;
++                     pairValue = pairValueArray + (2 + valueRecordPairSizeInBytes) * m;
++                     secondGlyph = ttUSHORT(pairValue);
++                     straw = secondGlyph;
++                     if (needle < straw)
++                        r = m - 1;
++                     else if (needle > straw)
++                        l = m + 1;
++                     else {
++                        stbtt_int16 xAdvance = ttSHORT(pairValue + 2);
++                        return xAdvance;
++                     }
++                  }
++               } else
++                  return 0;
++               break;
++            }
++
++            case 2: {
++               stbtt_uint16 valueFormat1 = ttUSHORT(table + 4);
++               stbtt_uint16 valueFormat2 = ttUSHORT(table + 6);
++               if (valueFormat1 == 4 && valueFormat2 == 0) { // Support more formats?
++                  stbtt_uint16 classDef1Offset = ttUSHORT(table + 8);
++                  stbtt_uint16 classDef2Offset = ttUSHORT(table + 10);
++                  int glyph1class = stbtt__GetGlyphClass(table + classDef1Offset, glyph1);
++                  int glyph2class = stbtt__GetGlyphClass(table + classDef2Offset, glyph2);
++
++                  stbtt_uint16 class1Count = ttUSHORT(table + 12);
++                  stbtt_uint16 class2Count = ttUSHORT(table + 14);
++                  stbtt_uint8 *class1Records, *class2Records;
++                  stbtt_int16 xAdvance;
++
++                  if (glyph1class < 0 || glyph1class >= class1Count) return 0; // malformed
++                  if (glyph2class < 0 || glyph2class >= class2Count) return 0; // malformed
++
++                  class1Records = table + 16;
++                  class2Records = class1Records + 2 * (glyph1class * class2Count);
++                  xAdvance = ttSHORT(class2Records + 2 * glyph2class);
++                  return xAdvance;
++               } else
++                  return 0;
++               break;
++            }
++
++            default:
++               return 0; // Unsupported position format
++         }
++      }
++   }
++
++   return 0;
++}
++
++STBTT_DEF int  stbtt_GetGlyphKernAdvance(const stbtt_fontinfo *info, int g1, int g2)
++{
++   int xAdvance = 0;
++
++   if (info->gpos)
++      xAdvance += stbtt__GetGlyphGPOSInfoAdvance(info, g1, g2);
++   else if (info->kern)
++      xAdvance += stbtt__GetGlyphKernInfoAdvance(info, g1, g2);
++
++   return xAdvance;
++}
++
+ STBTT_DEF int  stbtt_GetCodepointKernAdvance(const stbtt_fontinfo *info, int ch1, int ch2)
+ {
+-   if (!info->kern) // if no kerning table, don't waste time looking up both codepoint->glyphs
++   if (!info->kern && !info->gpos) // if no kerning table, don't waste time looking up both codepoint->glyphs
+       return 0;
+    return stbtt_GetGlyphKernAdvance(info, stbtt_FindGlyphIndex(info,ch1), stbtt_FindGlyphIndex(info,ch2));
+ }
+@@ -1528,6 +2638,17 @@ STBTT_DEF void stbtt_GetFontVMetrics(const stbtt_fontinfo *info, int *ascent, in
+    if (lineGap) *lineGap = ttSHORT(info->data+info->hhea + 8);
+ }
+ 
++STBTT_DEF int  stbtt_GetFontVMetricsOS2(const stbtt_fontinfo *info, int *typoAscent, int *typoDescent, int *typoLineGap)
++{
++   int tab = stbtt__find_table(info->data, info->fontstart, "OS/2");
++   if (!tab)
++      return 0;
++   if (typoAscent ) *typoAscent  = ttSHORT(info->data+tab + 68);
++   if (typoDescent) *typoDescent = ttSHORT(info->data+tab + 70);
++   if (typoLineGap) *typoLineGap = ttSHORT(info->data+tab + 72);
++   return 1;
++}
++
+ STBTT_DEF void stbtt_GetFontBoundingBox(const stbtt_fontinfo *info, int *x0, int *y0, int *x1, int *y1)
+ {
+    *x0 = ttSHORT(info->data + info->head + 36);
+@@ -1553,6 +2674,45 @@ STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *v)
+    STBTT_free(v, info->userdata);
+ }
+ 
++STBTT_DEF stbtt_uint8 *stbtt_FindSVGDoc(const stbtt_fontinfo *info, int gl)
++{
++   int i;
++   stbtt_uint8 *data = info->data;
++   stbtt_uint8 *svg_doc_list = data + stbtt__get_svg((stbtt_fontinfo *) info);
++
++   int numEntries = ttUSHORT(svg_doc_list);
++   stbtt_uint8 *svg_docs = svg_doc_list + 2;
++
++   for(i=0; i<numEntries; i++) {
++      stbtt_uint8 *svg_doc = svg_docs + (12 * i);
++      if ((gl >= ttUSHORT(svg_doc)) && (gl <= ttUSHORT(svg_doc + 2)))
++         return svg_doc;
++   }
++   return 0;
++}
++
++STBTT_DEF int stbtt_GetGlyphSVG(const stbtt_fontinfo *info, int gl, const char **svg)
++{
++   stbtt_uint8 *data = info->data;
++   stbtt_uint8 *svg_doc;
++
++   if (info->svg == 0)
++      return 0;
++
++   svg_doc = stbtt_FindSVGDoc(info, gl);
++   if (svg_doc != NULL) {
++      *svg = (char *) data + info->svg + ttULONG(svg_doc + 4);
++      return ttULONG(svg_doc + 8);
++   } else {
++      return 0;
++   }
++}
++
++STBTT_DEF int stbtt_GetCodepointSVG(const stbtt_fontinfo *info, int unicode_codepoint, const char **svg)
++{
++   return stbtt_GetGlyphSVG(info, stbtt_FindGlyphIndex(info, unicode_codepoint), svg);
++}
++
+ //////////////////////////////////////////////////////////////////////////////
+ //
+ // antialiasing software rasterizer
+@@ -1560,7 +2720,7 @@ STBTT_DEF void stbtt_FreeShape(const stbtt_fontinfo *info, stbtt_vertex *v)
+ 
+ STBTT_DEF void stbtt_GetGlyphBitmapBoxSubpixel(const stbtt_fontinfo *font, int glyph, float scale_x, float scale_y,float shift_x, float shift_y, int *ix0, int *iy0, int *ix1, int *iy1)
+ {
+-   int x0,y0,x1,y1;
++   int x0=0,y0=0,x1,y1; // =0 suppresses compiler warning
+    if (!stbtt_GetGlyphBox(font, glyph, &x0,&y0,&x1,&y1)) {
+       // e.g. space character
+       if (ix0) *ix0 = 0;
+@@ -1624,7 +2784,7 @@ static void *stbtt__hheap_alloc(stbtt__hheap *hh, size_t size, void *userdata)
+          hh->num_remaining_in_head_chunk = count;
+       }
+       --hh->num_remaining_in_head_chunk;
+-      return (char *) (hh->head) + size * hh->num_remaining_in_head_chunk;
++      return (char *) (hh->head) + sizeof(stbtt__hheap_chunk) + size * hh->num_remaining_in_head_chunk;
+    }
+ }
+ 
+@@ -1676,8 +2836,9 @@ static stbtt__active_edge *stbtt__new_active(stbtt__hheap *hh, stbtt__edge *e, i
+ {
+    stbtt__active_edge *z = (stbtt__active_edge *) stbtt__hheap_alloc(hh, sizeof(*z), userdata);
+    float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
++   STBTT_assert(z != NULL);
+    if (!z) return z;
+-   
++
+    // round dx down to avoid overshooting
+    if (dxdy < 0)
+       z->dx = -STBTT_ifloor(STBTT_FIX * -dxdy);
+@@ -1697,6 +2858,7 @@ static stbtt__active_edge *stbtt__new_active(stbtt__hheap *hh, stbtt__edge *e, i
+ {
+    stbtt__active_edge *z = (stbtt__active_edge *) stbtt__hheap_alloc(hh, sizeof(*z), userdata);
+    float dxdy = (e->x1 - e->x0) / (e->y1 - e->y0);
++   STBTT_assert(z != NULL);
+    //STBTT_assert(e->y0 <= start_point);
+    if (!z) return z;
+    z->fdx = dxdy;
+@@ -1754,7 +2916,7 @@ static void stbtt__fill_active_edges(unsigned char *scanline, int len, stbtt__ac
+             }
+          }
+       }
+-      
++
+       e = e->next;
+    }
+ }
+@@ -1768,13 +2930,10 @@ static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e,
+    int s; // vertical subsample index
+    unsigned char scanline_data[512], *scanline;
+ 
+-   if (result->w > 512) {
++   if (result->w > 512)
+       scanline = (unsigned char *) STBTT_malloc(result->w, userdata);
+-      if (!scanline)
+-         return;
+-   } else {
++   else
+       scanline = scanline_data;
+-   }
+ 
+    y = off_y * vsubsample;
+    e[n].y0 = (off_y + result->h) * (float) vsubsample + 1;
+@@ -1824,23 +2983,23 @@ static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e,
+          while (e->y0 <= scan_y) {
+             if (e->y1 > scan_y) {
+                stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y, userdata);
+-               if (!z)
+-                  return;
+-               // find insertion point
+-               if (active == NULL)
+-                  active = z;
+-               else if (z->x < active->x) {
+-                  // insert at front
+-                  z->next = active;
+-                  active = z;
+-               } else {
+-                  // find thing to insert AFTER
+-                  stbtt__active_edge *p = active;
+-                  while (p->next && p->next->x < z->x)
+-                     p = p->next;
+-                  // at this point, p->next->x is NOT < z->x
+-                  z->next = p->next;
+-                  p->next = z;
++               if (z != NULL) {
++                  // find insertion point
++                  if (active == NULL)
++                     active = z;
++                  else if (z->x < active->x) {
++                     // insert at front
++                     z->next = active;
++                     active = z;
++                  } else {
++                     // find thing to insert AFTER
++                     stbtt__active_edge *p = active;
++                     while (p->next && p->next->x < z->x)
++                        p = p->next;
++                     // at this point, p->next->x is NOT < z->x
++                     z->next = p->next;
++                     p->next = z;
++                  }
+                }
+             }
+             ++e;
+@@ -1903,6 +3062,23 @@ static void stbtt__handle_clipped_edge(float *scanline, int x, stbtt__active_edg
+    }
+ }
+ 
++static float stbtt__sized_trapezoid_area(float height, float top_width, float bottom_width)
++{
++   STBTT_assert(top_width >= 0);
++   STBTT_assert(bottom_width >= 0);
++   return (top_width + bottom_width) / 2.0f * height;
++}
++
++static float stbtt__position_trapezoid_area(float height, float tx0, float tx1, float bx0, float bx1)
++{
++   return stbtt__sized_trapezoid_area(height, tx1 - tx0, bx1 - bx0);
++}
++
++static float stbtt__sized_triangle_area(float height, float width)
++{
++   return height * width / 2;
++}
++
+ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill, int len, stbtt__active_edge *e, float y_top)
+ {
+    float y_bottom = y_top+1;
+@@ -1957,13 +3133,13 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill,
+                float height;
+                // simple case, only spans one pixel
+                int x = (int) x_top;
+-               height = sy1 - sy0;
++               height = (sy1 - sy0) * e->direction;
+                STBTT_assert(x >= 0 && x < len);
+-               scanline[x] += e->direction * (1-((x_top - x) + (x_bottom-x))/2)  * height;
+-               scanline_fill[x] += e->direction * height; // everything right of this pixel is filled
++               scanline[x]      += stbtt__position_trapezoid_area(height, x_top, x+1.0f, x_bottom, x+1.0f);
++               scanline_fill[x] += height; // everything right of this pixel is filled
+             } else {
+                int x,x1,x2;
+-               float y_crossing, step, sign, area;
++               float y_crossing, y_final, step, sign, area;
+                // covers 2+ pixels
+                if (x_top > x_bottom) {
+                   // flip scanline vertically; signed area is the same
+@@ -1976,29 +3152,79 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill,
+                   dy = -dy;
+                   t = x0, x0 = xb, xb = t;
+                }
++               STBTT_assert(dy >= 0);
++               STBTT_assert(dx >= 0);
+ 
+                x1 = (int) x_top;
+                x2 = (int) x_bottom;
+                // compute intersection with y axis at x1+1
+-               y_crossing = (x1+1 - x0) * dy + y_top;
++               y_crossing = y_top + dy * (x1+1 - x0);
++
++               // compute intersection with y axis at x2
++               y_final = y_top + dy * (x2 - x0);
++
++               //           x1    x_top                            x2    x_bottom
++               //     y_top  +------|-----+------------+------------+--------|---+------------+
++               //            |            |            |            |            |            |
++               //            |            |            |            |            |            |
++               //       sy0  |      Txxxxx|............|............|............|............|
++               // y_crossing |            *xxxxx.......|............|............|............|
++               //            |            |     xxxxx..|............|............|............|
++               //            |            |     /-   xx*xxxx........|............|............|
++               //            |            | dy <       |    xxxxxx..|............|............|
++               //   y_final  |            |     \-     |          xx*xxx.........|............|
++               //       sy1  |            |            |            |   xxxxxB...|............|
++               //            |            |            |            |            |            |
++               //            |            |            |            |            |            |
++               //  y_bottom  +------------+------------+------------+------------+------------+
++               //
++               // goal is to measure the area covered by '.' in each pixel
++
++               // if x2 is right at the right edge of x1, y_crossing can blow up, github #1057
++               // @TODO: maybe test against sy1 rather than y_bottom?
++               if (y_crossing > y_bottom)
++                  y_crossing = y_bottom;
+ 
+                sign = e->direction;
+-               // area of the rectangle covered from y0..y_crossing
++
++               // area of the rectangle covered from sy0..y_crossing
+                area = sign * (y_crossing-sy0);
+-               // area of the triangle (x_top,y0), (x+1,y0), (x+1,y_crossing)
+-               scanline[x1] += area * (1-((x_top - x1)+(x1+1-x1))/2);
+ 
+-               step = sign * dy;
++               // area of the triangle (x_top,sy0), (x1+1,sy0), (x1+1,y_crossing)
++               scanline[x1] += stbtt__sized_triangle_area(area, x1+1 - x_top);
++
++               // check if final y_crossing is blown up; no test case for this
++               if (y_final > y_bottom) {
++                  y_final = y_bottom;
++                  dy = (y_final - y_crossing ) / (x2 - (x1+1)); // if denom=0, y_final = y_crossing, so y_final <= y_bottom
++               }
++
++               // in second pixel, area covered by line segment found in first pixel
++               // is always a rectangle 1 wide * the height of that line segment; this
++               // is exactly what the variable 'area' stores. it also gets a contribution
++               // from the line segment within it. the THIRD pixel will get the first
++               // pixel's rectangle contribution, the second pixel's rectangle contribution,
++               // and its own contribution. the 'own contribution' is the same in every pixel except
++               // the leftmost and rightmost, a trapezoid that slides down in each pixel.
++               // the second pixel's contribution to the third pixel will be the
++               // rectangle 1 wide times the height change in the second pixel, which is dy.
++
++               step = sign * dy * 1; // dy is dy/dx, change in y for every 1 change in x,
++               // which multiplied by 1-pixel-width is how much pixel area changes for each step in x
++               // so the area advances by 'step' every time
++
+                for (x = x1+1; x < x2; ++x) {
+-                  scanline[x] += area + step/2;
++                  scanline[x] += area + step/2; // area of trapezoid is 1*step/2
+                   area += step;
+                }
+-               y_crossing += dy * (x2 - (x1+1));
+-
+-               STBTT_assert(fabs(area) <= 1.01f);
++               STBTT_assert(STBTT_fabs(area) <= 1.01f); // accumulated error from area += step unless we round step down
++               STBTT_assert(sy1 > y_final-0.01f);
+ 
+-               scanline[x2] += area + sign * (1-(x_bottom-x2)/2) * (sy1-y_crossing);
++               // area covered in the last pixel is the rectangle from all the pixels to the left,
++               // plus the trapezoid filled by the line segment in this pixel all the way to the right edge
++               scanline[x2] += area + sign * stbtt__position_trapezoid_area(sy1-y_final, (float) x2, x2+1.0f, x_bottom, x2+1.0f);
+ 
++               // the rest of the line is filled based on the total height of the line segment in this pixel
+                scanline_fill[x2] += sign * (sy1-sy0);
+             }
+          } else {
+@@ -2006,6 +3232,9 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill,
+             // clipping logic. since this does not match the intended use
+             // of this library, we use a different, very slow brute
+             // force implementation
++            // note though that this does happen some of the time because
++            // x_top and x_bottom can be extrapolated at the top & bottom of
++            // the shape and actually lie outside the bounding box
+             int x;
+             for (x=0; x < len; ++x) {
+                // cases:
+@@ -2021,19 +3250,18 @@ static void stbtt__fill_active_edges_new(float *scanline, float *scanline_fill,
+                // from the other y segment, and it might ignored as an empty segment. to avoid
+                // that, we need to explicitly produce segments based on x positions.
+ 
+-               // rename variables to clear pairs
++               // rename variables to clearly-defined pairs
+                float y0 = y_top;
+                float x1 = (float) (x);
+                float x2 = (float) (x+1);
+                float x3 = xb;
+                float y3 = y_bottom;
+-               float y1,y2;
+ 
+                // x = e->x + e->dx * (y-y_top)
+                // (y-y_top) = (x - e->x) / e->dx
+                // y = (x - e->x) / e->dx + y_top
+-               y1 = (x - x0) / dx + y_top;
+-               y2 = (x+1 - x0) / dx + y_top;
++               float y1 = (x - x0) / dx + y_top;
++               float y2 = (x+1 - x0) / dx + y_top;
+ 
+                if (x0 < x1 && x3 > x2) {         // three segments descending down-right
+                   stbtt__handle_clipped_edge(scanline,x,e, x0,y0, x1,y1);
+@@ -2073,13 +3301,12 @@ static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e,
+    int y,j=0, i;
+    float scanline_data[129], *scanline, *scanline2;
+ 
+-   if (result->w > 64) {
++   STBTT__NOTUSED(vsubsample);
++
++   if (result->w > 64)
+       scanline = (float *) STBTT_malloc((result->w*2+1) * sizeof(float), userdata);
+-      if (!scanline)
+-         return;
+-   } else {
++   else
+       scanline = scanline_data;
+-   }
+ 
+    scanline2 = scanline + result->w;
+ 
+@@ -2113,12 +3340,18 @@ static void stbtt__rasterize_sorted_edges(stbtt__bitmap *result, stbtt__edge *e,
+       while (e->y0 <= scan_y_bottom) {
+          if (e->y0 != e->y1) {
+             stbtt__active_edge *z = stbtt__new_active(&hh, e, off_x, scan_y_top, userdata);
+-            if (!z)
+-               return;
+-            STBTT_assert(z->ey >= scan_y_top);
+-            // insert at front
+-            z->next = active;
+-            active = z;
++            if (z != NULL) {
++               if (j == 0 && off_y != 0) {
++                  if (z->ey < scan_y_top) {
++                     // this can happen due to subpixel positioning and some kind of fp rounding error i think
++                     z->ey = scan_y_top;
++                  }
++               }
++               STBTT_assert(z->ey >= scan_y_top); // if we get really unlucky a tiny bit of an edge can be out of bounds
++               // insert at front
++               z->next = active;
++               active = z;
++            }
+          }
+          ++e;
+       }
+@@ -2183,7 +3416,7 @@ static void stbtt__sort_edges_ins_sort(stbtt__edge *p, int n)
+ 
+ static void stbtt__sort_edges_quicksort(stbtt__edge *p, int n)
+ {
+-   /* threshhold for transitioning to insertion sort */
++   /* threshold for transitioning to insertion sort */
+    while (n > 12) {
+       stbtt__edge t;
+       int c01,c12,c,m,i,j;
+@@ -2318,7 +3551,7 @@ static void stbtt__add_point(stbtt__point *points, int n, float x, float y)
+    points[n].y = y;
+ }
+ 
+-// tesselate until threshhold p is happy... @TODO warped to compensate for non-linear stretching
++// tessellate until threshold p is happy... @TODO warped to compensate for non-linear stretching
+ static int stbtt__tesselate_curve(stbtt__point *points, int *num_points, float x0, float y0, float x1, float y1, float x2, float y2, float objspace_flatness_squared, int n)
+ {
+    // midpoint
+@@ -2339,6 +3572,48 @@ static int stbtt__tesselate_curve(stbtt__point *points, int *num_points, float x
+    return 1;
+ }
+ 
++static void stbtt__tesselate_cubic(stbtt__point *points, int *num_points, float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3, float objspace_flatness_squared, int n)
++{
++   // @TODO this "flatness" calculation is just made-up nonsense that seems to work well enough
++   float dx0 = x1-x0;
++   float dy0 = y1-y0;
++   float dx1 = x2-x1;
++   float dy1 = y2-y1;
++   float dx2 = x3-x2;
++   float dy2 = y3-y2;
++   float dx = x3-x0;
++   float dy = y3-y0;
++   float longlen = (float) (STBTT_sqrt(dx0*dx0+dy0*dy0)+STBTT_sqrt(dx1*dx1+dy1*dy1)+STBTT_sqrt(dx2*dx2+dy2*dy2));
++   float shortlen = (float) STBTT_sqrt(dx*dx+dy*dy);
++   float flatness_squared = longlen*longlen-shortlen*shortlen;
++
++   if (n > 16) // 65536 segments on one curve better be enough!
++      return;
++
++   if (flatness_squared > objspace_flatness_squared) {
++      float x01 = (x0+x1)/2;
++      float y01 = (y0+y1)/2;
++      float x12 = (x1+x2)/2;
++      float y12 = (y1+y2)/2;
++      float x23 = (x2+x3)/2;
++      float y23 = (y2+y3)/2;
++
++      float xa = (x01+x12)/2;
++      float ya = (y01+y12)/2;
++      float xb = (x12+x23)/2;
++      float yb = (y12+y23)/2;
++
++      float mx = (xa+xb)/2;
++      float my = (ya+yb)/2;
++
++      stbtt__tesselate_cubic(points, num_points, x0,y0, x01,y01, xa,ya, mx,my, objspace_flatness_squared,n+1);
++      stbtt__tesselate_cubic(points, num_points, mx,my, xb,yb, x23,y23, x3,y3, objspace_flatness_squared,n+1);
++   } else {
++      stbtt__add_point(points, *num_points,x3,y3);
++      *num_points = *num_points+1;
++   }
++}
++
+ // returns number of contours
+ static stbtt__point *stbtt_FlattenCurves(stbtt_vertex *vertices, int num_verts, float objspace_flatness, int **contour_lengths, int *num_contours, void *userdata)
+ {
+@@ -2395,6 +3670,14 @@ static stbtt__point *stbtt_FlattenCurves(stbtt_vertex *vertices, int num_verts,
+                                         objspace_flatness_squared, 0);
+                x = vertices[i].x, y = vertices[i].y;
+                break;
++            case STBTT_vcubic:
++               stbtt__tesselate_cubic(points, &num_points, x,y,
++                                        vertices[i].cx, vertices[i].cy,
++                                        vertices[i].cx1, vertices[i].cy1,
++                                        vertices[i].x,  vertices[i].y,
++                                        objspace_flatness_squared, 0);
++               x = vertices[i].x, y = vertices[i].y;
++               break;
+          }
+       }
+       (*contour_lengths)[n] = num_points - start;
+@@ -2411,8 +3694,9 @@ static stbtt__point *stbtt_FlattenCurves(stbtt_vertex *vertices, int num_verts,
+ 
+ STBTT_DEF void stbtt_Rasterize(stbtt__bitmap *result, float flatness_in_pixels, stbtt_vertex *vertices, int num_verts, float scale_x, float scale_y, float shift_x, float shift_y, int x_off, int y_off, int invert, void *userdata)
+ {
+-   float scale = scale_x > scale_y ? scale_y : scale_x;
+-   int winding_count, *winding_lengths;
++   float scale            = scale_x > scale_y ? scale_y : scale_x;
++   int winding_count      = 0;
++   int *winding_lengths   = NULL;
+    stbtt__point *windings = stbtt_FlattenCurves(vertices, num_verts, flatness_in_pixels / scale, &winding_lengths, &winding_count, userdata);
+    if (windings) {
+       stbtt__rasterize(result, windings, winding_lengths, winding_count, scale_x, scale_y, shift_x, shift_y, x_off, y_off, invert, userdata);
+@@ -2430,7 +3714,7 @@ STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info
+ {
+    int ix0,iy0,ix1,iy1;
+    stbtt__bitmap gbm;
+-   stbtt_vertex *vertices;   
++   stbtt_vertex *vertices;
+    int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
+ 
+    if (scale_x == 0) scale_x = scale_y;
+@@ -2453,7 +3737,7 @@ STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info
+    if (height) *height = gbm.h;
+    if (xoff  ) *xoff   = ix0;
+    if (yoff  ) *yoff   = iy0;
+-   
++
+    if (gbm.w && gbm.h) {
+       gbm.pixels = (unsigned char *) STBTT_malloc(gbm.w * gbm.h, info->userdata);
+       if (gbm.pixels) {
+@@ -2464,7 +3748,7 @@ STBTT_DEF unsigned char *stbtt_GetGlyphBitmapSubpixel(const stbtt_fontinfo *info
+    }
+    STBTT_free(vertices, info->userdata);
+    return gbm.pixels;
+-}   
++}
+ 
+ STBTT_DEF unsigned char *stbtt_GetGlyphBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int glyph, int *width, int *height, int *xoff, int *yoff)
+ {
+@@ -2476,7 +3760,7 @@ STBTT_DEF void stbtt_MakeGlyphBitmapSubpixel(const stbtt_fontinfo *info, unsigne
+    int ix0,iy0;
+    stbtt_vertex *vertices;
+    int num_verts = stbtt_GetGlyphShape(info, glyph, &vertices);
+-   stbtt__bitmap gbm;   
++   stbtt__bitmap gbm;
+ 
+    stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale_x, scale_y, shift_x, shift_y, &ix0,&iy0,0,0);
+    gbm.pixels = output;
+@@ -2498,7 +3782,12 @@ STBTT_DEF void stbtt_MakeGlyphBitmap(const stbtt_fontinfo *info, unsigned char *
+ STBTT_DEF unsigned char *stbtt_GetCodepointBitmapSubpixel(const stbtt_fontinfo *info, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint, int *width, int *height, int *xoff, int *yoff)
+ {
+    return stbtt_GetGlyphBitmapSubpixel(info, scale_x, scale_y,shift_x,shift_y, stbtt_FindGlyphIndex(info,codepoint), width,height,xoff,yoff);
+-}   
++}
++
++STBTT_DEF void stbtt_MakeCodepointBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int oversample_x, int oversample_y, float *sub_x, float *sub_y, int codepoint)
++{
++   stbtt_MakeGlyphBitmapSubpixelPrefilter(info, output, out_w, out_h, out_stride, scale_x, scale_y, shift_x, shift_y, oversample_x, oversample_y, sub_x, sub_y, stbtt_FindGlyphIndex(info,codepoint));
++}
+ 
+ STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int codepoint)
+ {
+@@ -2508,7 +3797,7 @@ STBTT_DEF void stbtt_MakeCodepointBitmapSubpixel(const stbtt_fontinfo *info, uns
+ STBTT_DEF unsigned char *stbtt_GetCodepointBitmap(const stbtt_fontinfo *info, float scale_x, float scale_y, int codepoint, int *width, int *height, int *xoff, int *yoff)
+ {
+    return stbtt_GetCodepointBitmapSubpixel(info, scale_x, scale_y, 0.0f,0.0f, codepoint, width,height,xoff,yoff);
+-}   
++}
+ 
+ STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, int codepoint)
+ {
+@@ -2521,7 +3810,7 @@ STBTT_DEF void stbtt_MakeCodepointBitmap(const stbtt_fontinfo *info, unsigned ch
+ //
+ // This is SUPER-CRAPPY packing to keep source code small
+ 
+-STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // font location (use offset=0 for plain .ttf)
++static int stbtt_BakeFontBitmap_internal(unsigned char *data, int offset,  // font location (use offset=0 for plain .ttf)
+                                 float pixel_height,                     // height of font in pixels
+                                 unsigned char *pixels, int pw, int ph,  // bitmap to be filled in
+                                 int first_char, int num_chars,          // characters to bake
+@@ -2530,6 +3819,7 @@ STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // fo
+    float scale;
+    int x,y,bottom_y, i;
+    stbtt_fontinfo f;
++   f.userdata = NULL;
+    if (!stbtt_InitFont(&f, data, offset))
+       return -1;
+    STBTT_memset(pixels, 0, pw*ph); // background of 0 around pixels
+@@ -2566,11 +3856,11 @@ STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,  // fo
+    return bottom_y;
+ }
+ 
+-STBTT_DEF void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int opengl_fillrule)
++STBTT_DEF void stbtt_GetBakedQuad(const stbtt_bakedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int opengl_fillrule)
+ {
+    float d3d_bias = opengl_fillrule ? 0 : -0.5f;
+    float ipw = 1.0f / pw, iph = 1.0f / ph;
+-   stbtt_bakedchar *b = chardata + char_index;
++   const stbtt_bakedchar *b = chardata + char_index;
+    int round_x = STBTT_ifloor((*xpos + b->xoff) + 0.5f);
+    int round_y = STBTT_ifloor((*ypos + b->yoff) + 0.5f);
+ 
+@@ -2593,11 +3883,6 @@ STBTT_DEF void stbtt_GetBakedQuad(stbtt_bakedchar *chardata, int pw, int ph, int
+ //
+ 
+ #ifndef STB_RECT_PACK_VERSION
+-#ifdef _MSC_VER
+-#define STBTT__NOTUSED(v)  (void)(v)
+-#else
+-#define STBTT__NOTUSED(v)  (void)sizeof(v)
+-#endif
+ 
+ typedef int stbrp_coord;
+ 
+@@ -2637,7 +3922,7 @@ static void stbrp_init_target(stbrp_context *con, int pw, int ph, stbrp_node *no
+    con->y = 0;
+    con->bottom_y = 0;
+    STBTT__NOTUSED(nodes);
+-   STBTT__NOTUSED(num_nodes);   
++   STBTT__NOTUSED(num_nodes);
+ }
+ 
+ static void stbrp_pack_rects(stbrp_context *con, stbrp_rect *rects, int num_rects)
+@@ -2691,6 +3976,7 @@ STBTT_DEF int stbtt_PackBegin(stbtt_pack_context *spc, unsigned char *pixels, in
+    spc->stride_in_bytes = stride_in_bytes != 0 ? stride_in_bytes : pw;
+    spc->h_oversample = 1;
+    spc->v_oversample = 1;
++   spc->skip_missing = 0;
+ 
+    stbrp_init_target(context, pw-padding, ph-padding, nodes, num_nodes);
+ 
+@@ -2716,6 +4002,11 @@ STBTT_DEF void stbtt_PackSetOversampling(stbtt_pack_context *spc, unsigned int h
+       spc->v_oversample = v_oversample;
+ }
+ 
++STBTT_DEF void stbtt_PackSetSkipMissingCodepoints(stbtt_pack_context *spc, int skip)
++{
++   spc->skip_missing = skip;
++}
++
+ #define STBTT__OVER_MASK  (STBTT_MAX_OVERSAMPLE-1)
+ 
+ static void stbtt__h_prefilter(unsigned char *pixels, int w, int h, int stride_in_bytes, unsigned int kernel_width)
+@@ -2723,6 +4014,7 @@ static void stbtt__h_prefilter(unsigned char *pixels, int w, int h, int stride_i
+    unsigned char buffer[STBTT_MAX_OVERSAMPLE];
+    int safe_w = w - kernel_width;
+    int j;
++   STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE); // suppress bogus warning from VS2013 -analyze
+    for (j=0; j < h; ++j) {
+       int i;
+       unsigned int total;
+@@ -2784,6 +4076,7 @@ static void stbtt__v_prefilter(unsigned char *pixels, int w, int h, int stride_i
+    unsigned char buffer[STBTT_MAX_OVERSAMPLE];
+    int safe_h = h - kernel_width;
+    int j;
++   STBTT_memset(buffer, 0, STBTT_MAX_OVERSAMPLE); // suppress bogus warning from VS2013 -analyze
+    for (j=0; j < w; ++j) {
+       int i;
+       unsigned int total;
+@@ -2853,9 +4146,10 @@ static float stbtt__oversample_shift(int oversample)
+ }
+ 
+ // rects array must be big enough to accommodate all characters in the given ranges
+-STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
++STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
+ {
+    int i,j,k;
++   int missing_glyph_added = 0;
+ 
+    k=0;
+    for (i=0; i < num_ranges; ++i) {
+@@ -2867,13 +4161,19 @@ STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fon
+          int x0,y0,x1,y1;
+          int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
+          int glyph = stbtt_FindGlyphIndex(info, codepoint);
+-         stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
+-                                         scale * spc->h_oversample,
+-                                         scale * spc->v_oversample,
+-                                         0,0,
+-                                         &x0,&y0,&x1,&y1);
+-         rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
+-         rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
++         if (glyph == 0 && (spc->skip_missing || missing_glyph_added)) {
++            rects[k].w = rects[k].h = 0;
++         } else {
++            stbtt_GetGlyphBitmapBoxSubpixel(info,glyph,
++                                            scale * spc->h_oversample,
++                                            scale * spc->v_oversample,
++                                            0,0,
++                                            &x0,&y0,&x1,&y1);
++            rects[k].w = (stbrp_coord) (x1-x0 + spc->padding + spc->h_oversample-1);
++            rects[k].h = (stbrp_coord) (y1-y0 + spc->padding + spc->v_oversample-1);
++            if (glyph == 0)
++               missing_glyph_added = 1;
++         }
+          ++k;
+       }
+    }
+@@ -2881,10 +4181,33 @@ STBTT_DEF int stbtt_PackFontRangesGatherRects(stbtt_pack_context *spc, stbtt_fon
+    return k;
+ }
+ 
++STBTT_DEF void stbtt_MakeGlyphBitmapSubpixelPrefilter(const stbtt_fontinfo *info, unsigned char *output, int out_w, int out_h, int out_stride, float scale_x, float scale_y, float shift_x, float shift_y, int prefilter_x, int prefilter_y, float *sub_x, float *sub_y, int glyph)
++{
++   stbtt_MakeGlyphBitmapSubpixel(info,
++                                 output,
++                                 out_w - (prefilter_x - 1),
++                                 out_h - (prefilter_y - 1),
++                                 out_stride,
++                                 scale_x,
++                                 scale_y,
++                                 shift_x,
++                                 shift_y,
++                                 glyph);
++
++   if (prefilter_x > 1)
++      stbtt__h_prefilter(output, out_w, out_h, out_stride, prefilter_x);
++
++   if (prefilter_y > 1)
++      stbtt__v_prefilter(output, out_w, out_h, out_stride, prefilter_y);
++
++   *sub_x = stbtt__oversample_shift(prefilter_x);
++   *sub_y = stbtt__oversample_shift(prefilter_y);
++}
++
+ // rects array must be big enough to accommodate all characters in the given ranges
+-STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
++STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, const stbtt_fontinfo *info, stbtt_pack_range *ranges, int num_ranges, stbrp_rect *rects)
+ {
+-   int i,j,k, return_value = 1;
++   int i,j,k, missing_glyph = -1, return_value = 1;
+ 
+    // save current values
+    int old_h_over = spc->h_oversample;
+@@ -2903,7 +4226,7 @@ STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt
+       sub_y = stbtt__oversample_shift(spc->v_oversample);
+       for (j=0; j < ranges[i].num_chars; ++j) {
+          stbrp_rect *r = &rects[k];
+-         if (r->was_packed) {
++         if (r->was_packed && r->w != 0 && r->h != 0) {
+             stbtt_packedchar *bc = &ranges[i].chardata_for_range[j];
+             int advance, lsb, x0,y0,x1,y1;
+             int codepoint = ranges[i].array_of_unicode_codepoints == NULL ? ranges[i].first_unicode_codepoint_in_range + j : ranges[i].array_of_unicode_codepoints[j];
+@@ -2949,6 +4272,13 @@ STBTT_DEF int stbtt_PackFontRangesRenderIntoRects(stbtt_pack_context *spc, stbtt
+             bc->yoff     =       (float)  y0 * recip_v + sub_y;
+             bc->xoff2    =                (x0 + r->w) * recip_h + sub_x;
+             bc->yoff2    =                (y0 + r->h) * recip_v + sub_y;
++
++            if (glyph == 0)
++               missing_glyph = j;
++         } else if (spc->skip_missing) {
++            return_value = 0;
++         } else if (r->was_packed && r->w == 0 && r->h == 0 && missing_glyph >= 0) {
++            ranges[i].chardata_for_range[j] = ranges[i].chardata_for_range[missing_glyph];
+          } else {
+             return_value = 0; // if any fail, report failure
+          }
+@@ -2969,7 +4299,7 @@ STBTT_DEF void stbtt_PackFontRangesPackRects(stbtt_pack_context *spc, stbrp_rect
+    stbrp_pack_rects((stbrp_context *) spc->pack_info, rects, num_rects);
+ }
+ 
+-STBTT_DEF int stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges)
++STBTT_DEF int stbtt_PackFontRanges(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, stbtt_pack_range *ranges, int num_ranges)
+ {
+    stbtt_fontinfo info;
+    int i,j,n, return_value = 1;
+@@ -2987,24 +4317,25 @@ STBTT_DEF int stbtt_PackFontRanges(stbtt_pack_context *spc, unsigned char *fontd
+    n = 0;
+    for (i=0; i < num_ranges; ++i)
+       n += ranges[i].num_chars;
+-         
++
+    rects = (stbrp_rect *) STBTT_malloc(sizeof(*rects) * n, spc->user_allocator_context);
+    if (rects == NULL)
+       return 0;
+ 
++   info.userdata = spc->user_allocator_context;
+    stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata,font_index));
+ 
+    n = stbtt_PackFontRangesGatherRects(spc, &info, ranges, num_ranges, rects);
+ 
+    stbtt_PackFontRangesPackRects(spc, rects, n);
+-  
++
+    return_value = stbtt_PackFontRangesRenderIntoRects(spc, &info, ranges, num_ranges, rects);
+ 
+    STBTT_free(rects, spc->user_allocator_context);
+    return return_value;
+ }
+ 
+-STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc, unsigned char *fontdata, int font_index, float font_size,
++STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc, const unsigned char *fontdata, int font_index, float font_size,
+             int first_unicode_codepoint_in_range, int num_chars_in_range, stbtt_packedchar *chardata_for_range)
+ {
+    stbtt_pack_range range;
+@@ -3016,10 +4347,23 @@ STBTT_DEF int stbtt_PackFontRange(stbtt_pack_context *spc, unsigned char *fontda
+    return stbtt_PackFontRanges(spc, fontdata, font_index, &range, 1);
+ }
+ 
+-STBTT_DEF void stbtt_GetPackedQuad(stbtt_packedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int align_to_integer)
++STBTT_DEF void stbtt_GetScaledFontVMetrics(const unsigned char *fontdata, int index, float size, float *ascent, float *descent, float *lineGap)
++{
++   int i_ascent, i_descent, i_lineGap;
++   float scale;
++   stbtt_fontinfo info;
++   stbtt_InitFont(&info, fontdata, stbtt_GetFontOffsetForIndex(fontdata, index));
++   scale = size > 0 ? stbtt_ScaleForPixelHeight(&info, size) : stbtt_ScaleForMappingEmToPixels(&info, -size);
++   stbtt_GetFontVMetrics(&info, &i_ascent, &i_descent, &i_lineGap);
++   *ascent  = (float) i_ascent  * scale;
++   *descent = (float) i_descent * scale;
++   *lineGap = (float) i_lineGap * scale;
++}
++
++STBTT_DEF void stbtt_GetPackedQuad(const stbtt_packedchar *chardata, int pw, int ph, int char_index, float *xpos, float *ypos, stbtt_aligned_quad *q, int align_to_integer)
+ {
+    float ipw = 1.0f / pw, iph = 1.0f / ph;
+-   stbtt_packedchar *b = chardata + char_index;
++   const stbtt_packedchar *b = chardata + char_index;
+ 
+    if (align_to_integer) {
+       float x = (float) STBTT_ifloor((*xpos + b->xoff) + 0.5f);
+@@ -3043,6 +4387,385 @@ STBTT_DEF void stbtt_GetPackedQuad(stbtt_packedchar *chardata, int pw, int ph, i
+    *xpos += b->xadvance;
+ }
+ 
++//////////////////////////////////////////////////////////////////////////////
++//
++// sdf computation
++//
++
++#define STBTT_min(a,b)  ((a) < (b) ? (a) : (b))
++#define STBTT_max(a,b)  ((a) < (b) ? (b) : (a))
++
++static int stbtt__ray_intersect_bezier(float orig[2], float ray[2], float q0[2], float q1[2], float q2[2], float hits[2][2])
++{
++   float q0perp = q0[1]*ray[0] - q0[0]*ray[1];
++   float q1perp = q1[1]*ray[0] - q1[0]*ray[1];
++   float q2perp = q2[1]*ray[0] - q2[0]*ray[1];
++   float roperp = orig[1]*ray[0] - orig[0]*ray[1];
++
++   float a = q0perp - 2*q1perp + q2perp;
++   float b = q1perp - q0perp;
++   float c = q0perp - roperp;
++
++   float s0 = 0., s1 = 0.;
++   int num_s = 0;
++
++   if (a != 0.0) {
++      float discr = b*b - a*c;
++      if (discr > 0.0) {
++         float rcpna = -1 / a;
++         float d = (float) STBTT_sqrt(discr);
++         s0 = (b+d) * rcpna;
++         s1 = (b-d) * rcpna;
++         if (s0 >= 0.0 && s0 <= 1.0)
++            num_s = 1;
++         if (d > 0.0 && s1 >= 0.0 && s1 <= 1.0) {
++            if (num_s == 0) s0 = s1;
++            ++num_s;
++         }
++      }
++   } else {
++      // 2*b*s + c = 0
++      // s = -c / (2*b)
++      s0 = c / (-2 * b);
++      if (s0 >= 0.0 && s0 <= 1.0)
++         num_s = 1;
++   }
++
++   if (num_s == 0)
++      return 0;
++   else {
++      float rcp_len2 = 1 / (ray[0]*ray[0] + ray[1]*ray[1]);
++      float rayn_x = ray[0] * rcp_len2, rayn_y = ray[1] * rcp_len2;
++
++      float q0d =   q0[0]*rayn_x +   q0[1]*rayn_y;
++      float q1d =   q1[0]*rayn_x +   q1[1]*rayn_y;
++      float q2d =   q2[0]*rayn_x +   q2[1]*rayn_y;
++      float rod = orig[0]*rayn_x + orig[1]*rayn_y;
++
++      float q10d = q1d - q0d;
++      float q20d = q2d - q0d;
++      float q0rd = q0d - rod;
++
++      hits[0][0] = q0rd + s0*(2.0f - 2.0f*s0)*q10d + s0*s0*q20d;
++      hits[0][1] = a*s0+b;
++
++      if (num_s > 1) {
++         hits[1][0] = q0rd + s1*(2.0f - 2.0f*s1)*q10d + s1*s1*q20d;
++         hits[1][1] = a*s1+b;
++         return 2;
++      } else {
++         return 1;
++      }
++   }
++}
++
++static int equal(float *a, float *b)
++{
++   return (a[0] == b[0] && a[1] == b[1]);
++}
++
++static int stbtt__compute_crossings_x(float x, float y, int nverts, stbtt_vertex *verts)
++{
++   int i;
++   float orig[2], ray[2] = { 1, 0 };
++   float y_frac;
++   int winding = 0;
++
++   // make sure y never passes through a vertex of the shape
++   y_frac = (float) STBTT_fmod(y, 1.0f);
++   if (y_frac < 0.01f)
++      y += 0.01f;
++   else if (y_frac > 0.99f)
++      y -= 0.01f;
++
++   orig[0] = x;
++   orig[1] = y;
++
++   // test a ray from (-infinity,y) to (x,y)
++   for (i=0; i < nverts; ++i) {
++      if (verts[i].type == STBTT_vline) {
++         int x0 = (int) verts[i-1].x, y0 = (int) verts[i-1].y;
++         int x1 = (int) verts[i  ].x, y1 = (int) verts[i  ].y;
++         if (y > STBTT_min(y0,y1) && y < STBTT_max(y0,y1) && x > STBTT_min(x0,x1)) {
++            float x_inter = (y - y0) / (y1 - y0) * (x1-x0) + x0;
++            if (x_inter < x)
++               winding += (y0 < y1) ? 1 : -1;
++         }
++      }
++      if (verts[i].type == STBTT_vcurve) {
++         int x0 = (int) verts[i-1].x , y0 = (int) verts[i-1].y ;
++         int x1 = (int) verts[i  ].cx, y1 = (int) verts[i  ].cy;
++         int x2 = (int) verts[i  ].x , y2 = (int) verts[i  ].y ;
++         int ax = STBTT_min(x0,STBTT_min(x1,x2)), ay = STBTT_min(y0,STBTT_min(y1,y2));
++         int by = STBTT_max(y0,STBTT_max(y1,y2));
++         if (y > ay && y < by && x > ax) {
++            float q0[2],q1[2],q2[2];
++            float hits[2][2];
++            q0[0] = (float)x0;
++            q0[1] = (float)y0;
++            q1[0] = (float)x1;
++            q1[1] = (float)y1;
++            q2[0] = (float)x2;
++            q2[1] = (float)y2;
++            if (equal(q0,q1) || equal(q1,q2)) {
++               x0 = (int)verts[i-1].x;
++               y0 = (int)verts[i-1].y;
++               x1 = (int)verts[i  ].x;
++               y1 = (int)verts[i  ].y;
++               if (y > STBTT_min(y0,y1) && y < STBTT_max(y0,y1) && x > STBTT_min(x0,x1)) {
++                  float x_inter = (y - y0) / (y1 - y0) * (x1-x0) + x0;
++                  if (x_inter < x)
++                     winding += (y0 < y1) ? 1 : -1;
++               }
++            } else {
++               int num_hits = stbtt__ray_intersect_bezier(orig, ray, q0, q1, q2, hits);
++               if (num_hits >= 1)
++                  if (hits[0][0] < 0)
++                     winding += (hits[0][1] < 0 ? -1 : 1);
++               if (num_hits >= 2)
++                  if (hits[1][0] < 0)
++                     winding += (hits[1][1] < 0 ? -1 : 1);
++            }
++         }
++      }
++   }
++   return winding;
++}
++
++static float stbtt__cuberoot( float x )
++{
++   if (x<0)
++      return -(float) STBTT_pow(-x,1.0f/3.0f);
++   else
++      return  (float) STBTT_pow( x,1.0f/3.0f);
++}
++
++// x^3 + a*x^2 + b*x + c = 0
++static int stbtt__solve_cubic(float a, float b, float c, float* r)
++{
++   float s = -a / 3;
++   float p = b - a*a / 3;
++   float q = a * (2*a*a - 9*b) / 27 + c;
++   float p3 = p*p*p;
++   float d = q*q + 4*p3 / 27;
++   if (d >= 0) {
++      float z = (float) STBTT_sqrt(d);
++      float u = (-q + z) / 2;
++      float v = (-q - z) / 2;
++      u = stbtt__cuberoot(u);
++      v = stbtt__cuberoot(v);
++      r[0] = s + u + v;
++      return 1;
++   } else {
++      float u = (float) STBTT_sqrt(-p/3);
++      float v = (float) STBTT_acos(-STBTT_sqrt(-27/p3) * q / 2) / 3; // p3 must be negative, since d is negative
++      float m = (float) STBTT_cos(v);
++      float n = (float) STBTT_cos(v-3.141592/2)*1.732050808f;
++      r[0] = s + u * 2 * m;
++      r[1] = s - u * (m + n);
++      r[2] = s - u * (m - n);
++
++      //STBTT_assert( STBTT_fabs(((r[0]+a)*r[0]+b)*r[0]+c) < 0.05f);  // these asserts may not be safe at all scales, though they're in bezier t parameter units so maybe?
++      //STBTT_assert( STBTT_fabs(((r[1]+a)*r[1]+b)*r[1]+c) < 0.05f);
++      //STBTT_assert( STBTT_fabs(((r[2]+a)*r[2]+b)*r[2]+c) < 0.05f);
++      return 3;
++   }
++}
++
++STBTT_DEF unsigned char * stbtt_GetGlyphSDF(const stbtt_fontinfo *info, float scale, int glyph, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff)
++{
++   float scale_x = scale, scale_y = scale;
++   int ix0,iy0,ix1,iy1;
++   int w,h;
++   unsigned char *data;
++
++   if (scale == 0) return NULL;
++
++   stbtt_GetGlyphBitmapBoxSubpixel(info, glyph, scale, scale, 0.0f,0.0f, &ix0,&iy0,&ix1,&iy1);
++
++   // if empty, return NULL
++   if (ix0 == ix1 || iy0 == iy1)
++      return NULL;
++
++   ix0 -= padding;
++   iy0 -= padding;
++   ix1 += padding;
++   iy1 += padding;
++
++   w = (ix1 - ix0);
++   h = (iy1 - iy0);
++
++   if (width ) *width  = w;
++   if (height) *height = h;
++   if (xoff  ) *xoff   = ix0;
++   if (yoff  ) *yoff   = iy0;
++
++   // invert for y-downwards bitmaps
++   scale_y = -scale_y;
++
++   {
++      int x,y,i,j;
++      float *precompute;
++      stbtt_vertex *verts;
++      int num_verts = stbtt_GetGlyphShape(info, glyph, &verts);
++      data = (unsigned char *) STBTT_malloc(w * h, info->userdata);
++      precompute = (float *) STBTT_malloc(num_verts * sizeof(float), info->userdata);
++
++      for (i=0,j=num_verts-1; i < num_verts; j=i++) {
++         if (verts[i].type == STBTT_vline) {
++            float x0 = verts[i].x*scale_x, y0 = verts[i].y*scale_y;
++            float x1 = verts[j].x*scale_x, y1 = verts[j].y*scale_y;
++            float dist = (float) STBTT_sqrt((x1-x0)*(x1-x0) + (y1-y0)*(y1-y0));
++            precompute[i] = (dist == 0) ? 0.0f : 1.0f / dist;
++         } else if (verts[i].type == STBTT_vcurve) {
++            float x2 = verts[j].x *scale_x, y2 = verts[j].y *scale_y;
++            float x1 = verts[i].cx*scale_x, y1 = verts[i].cy*scale_y;
++            float x0 = verts[i].x *scale_x, y0 = verts[i].y *scale_y;
++            float bx = x0 - 2*x1 + x2, by = y0 - 2*y1 + y2;
++            float len2 = bx*bx + by*by;
++            if (len2 != 0.0f)
++               precompute[i] = 1.0f / (bx*bx + by*by);
++            else
++               precompute[i] = 0.0f;
++         } else
++            precompute[i] = 0.0f;
++      }
++
++      for (y=iy0; y < iy1; ++y) {
++         for (x=ix0; x < ix1; ++x) {
++            float val;
++            float min_dist = 999999.0f;
++            float sx = (float) x + 0.5f;
++            float sy = (float) y + 0.5f;
++            float x_gspace = (sx / scale_x);
++            float y_gspace = (sy / scale_y);
++
++            int winding = stbtt__compute_crossings_x(x_gspace, y_gspace, num_verts, verts); // @OPTIMIZE: this could just be a rasterization, but needs to be line vs. non-tesselated curves so a new path
++
++            for (i=0; i < num_verts; ++i) {
++               float x0 = verts[i].x*scale_x, y0 = verts[i].y*scale_y;
++
++               if (verts[i].type == STBTT_vline && precompute[i] != 0.0f) {
++                  float x1 = verts[i-1].x*scale_x, y1 = verts[i-1].y*scale_y;
++
++                  float dist,dist2 = (x0-sx)*(x0-sx) + (y0-sy)*(y0-sy);
++                  if (dist2 < min_dist*min_dist)
++                     min_dist = (float) STBTT_sqrt(dist2);
++
++                  // coarse culling against bbox
++                  //if (sx > STBTT_min(x0,x1)-min_dist && sx < STBTT_max(x0,x1)+min_dist &&
++                  //    sy > STBTT_min(y0,y1)-min_dist && sy < STBTT_max(y0,y1)+min_dist)
++                  dist = (float) STBTT_fabs((x1-x0)*(y0-sy) - (y1-y0)*(x0-sx)) * precompute[i];
++                  STBTT_assert(i != 0);
++                  if (dist < min_dist) {
++                     // check position along line
++                     // x' = x0 + t*(x1-x0), y' = y0 + t*(y1-y0)
++                     // minimize (x'-sx)*(x'-sx)+(y'-sy)*(y'-sy)
++                     float dx = x1-x0, dy = y1-y0;
++                     float px = x0-sx, py = y0-sy;
++                     // minimize (px+t*dx)^2 + (py+t*dy)^2 = px*px + 2*px*dx*t + t^2*dx*dx + py*py + 2*py*dy*t + t^2*dy*dy
++                     // derivative: 2*px*dx + 2*py*dy + (2*dx*dx+2*dy*dy)*t, set to 0 and solve
++                     float t = -(px*dx + py*dy) / (dx*dx + dy*dy);
++                     if (t >= 0.0f && t <= 1.0f)
++                        min_dist = dist;
++                  }
++               } else if (verts[i].type == STBTT_vcurve) {
++                  float x2 = verts[i-1].x *scale_x, y2 = verts[i-1].y *scale_y;
++                  float x1 = verts[i  ].cx*scale_x, y1 = verts[i  ].cy*scale_y;
++                  float box_x0 = STBTT_min(STBTT_min(x0,x1),x2);
++                  float box_y0 = STBTT_min(STBTT_min(y0,y1),y2);
++                  float box_x1 = STBTT_max(STBTT_max(x0,x1),x2);
++                  float box_y1 = STBTT_max(STBTT_max(y0,y1),y2);
++                  // coarse culling against bbox to avoid computing cubic unnecessarily
++                  if (sx > box_x0-min_dist && sx < box_x1+min_dist && sy > box_y0-min_dist && sy < box_y1+min_dist) {
++                     int num=0;
++                     float ax = x1-x0, ay = y1-y0;
++                     float bx = x0 - 2*x1 + x2, by = y0 - 2*y1 + y2;
++                     float mx = x0 - sx, my = y0 - sy;
++                     float res[3] = {0.f,0.f,0.f};
++                     float px,py,t,it,dist2;
++                     float a_inv = precompute[i];
++                     if (a_inv == 0.0) { // if a_inv is 0, it's 2nd degree so use quadratic formula
++                        float a = 3*(ax*bx + ay*by);
++                        float b = 2*(ax*ax + ay*ay) + (mx*bx+my*by);
++                        float c = mx*ax+my*ay;
++                        if (a == 0.0) { // if a is 0, it's linear
++                           if (b != 0.0) {
++                              res[num++] = -c/b;
++                           }
++                        } else {
++                           float discriminant = b*b - 4*a*c;
++                           if (discriminant < 0)
++                              num = 0;
++                           else {
++                              float root = (float) STBTT_sqrt(discriminant);
++                              res[0] = (-b - root)/(2*a);
++                              res[1] = (-b + root)/(2*a);
++                              num = 2; // don't bother distinguishing 1-solution case, as code below will still work
++                           }
++                        }
++                     } else {
++                        float b = 3*(ax*bx + ay*by) * a_inv; // could precompute this as it doesn't depend on sample point
++                        float c = (2*(ax*ax + ay*ay) + (mx*bx+my*by)) * a_inv;
++                        float d = (mx*ax+my*ay) * a_inv;
++                        num = stbtt__solve_cubic(b, c, d, res);
++                     }
++                     dist2 = (x0-sx)*(x0-sx) + (y0-sy)*(y0-sy);
++                     if (dist2 < min_dist*min_dist)
++                        min_dist = (float) STBTT_sqrt(dist2);
++
++                     if (num >= 1 && res[0] >= 0.0f && res[0] <= 1.0f) {
++                        t = res[0], it = 1.0f - t;
++                        px = it*it*x0 + 2*t*it*x1 + t*t*x2;
++                        py = it*it*y0 + 2*t*it*y1 + t*t*y2;
++                        dist2 = (px-sx)*(px-sx) + (py-sy)*(py-sy);
++                        if (dist2 < min_dist * min_dist)
++                           min_dist = (float) STBTT_sqrt(dist2);
++                     }
++                     if (num >= 2 && res[1] >= 0.0f && res[1] <= 1.0f) {
++                        t = res[1], it = 1.0f - t;
++                        px = it*it*x0 + 2*t*it*x1 + t*t*x2;
++                        py = it*it*y0 + 2*t*it*y1 + t*t*y2;
++                        dist2 = (px-sx)*(px-sx) + (py-sy)*(py-sy);
++                        if (dist2 < min_dist * min_dist)
++                           min_dist = (float) STBTT_sqrt(dist2);
++                     }
++                     if (num >= 3 && res[2] >= 0.0f && res[2] <= 1.0f) {
++                        t = res[2], it = 1.0f - t;
++                        px = it*it*x0 + 2*t*it*x1 + t*t*x2;
++                        py = it*it*y0 + 2*t*it*y1 + t*t*y2;
++                        dist2 = (px-sx)*(px-sx) + (py-sy)*(py-sy);
++                        if (dist2 < min_dist * min_dist)
++                           min_dist = (float) STBTT_sqrt(dist2);
++                     }
++                  }
++               }
++            }
++            if (winding == 0)
++               min_dist = -min_dist;  // if outside the shape, value is negative
++            val = onedge_value + pixel_dist_scale * min_dist;
++            if (val < 0)
++               val = 0;
++            else if (val > 255)
++               val = 255;
++            data[(y-iy0)*w+(x-ix0)] = (unsigned char) val;
++         }
++      }
++      STBTT_free(precompute, info->userdata);
++      STBTT_free(verts, info->userdata);
++   }
++   return data;
++}
++
++STBTT_DEF unsigned char * stbtt_GetCodepointSDF(const stbtt_fontinfo *info, float scale, int codepoint, int padding, unsigned char onedge_value, float pixel_dist_scale, int *width, int *height, int *xoff, int *yoff)
++{
++   return stbtt_GetGlyphSDF(info, scale, stbtt_FindGlyphIndex(info, codepoint), padding, onedge_value, pixel_dist_scale, width, height, xoff, yoff);
++}
++
++STBTT_DEF void stbtt_FreeSDF(unsigned char *bitmap, void *userdata)
++{
++   STBTT_free(bitmap, userdata);
++}
+ 
+ //////////////////////////////////////////////////////////////////////////////
+ //
+@@ -3050,7 +4773,7 @@ STBTT_DEF void stbtt_GetPackedQuad(stbtt_packedchar *chardata, int pw, int ph, i
+ //
+ 
+ // check if a utf8 string contains a prefix which is the utf16 string; if so return length of matching utf8 string
+-static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(const stbtt_uint8 *s1, stbtt_int32 len1, const stbtt_uint8 *s2, stbtt_int32 len2) 
++static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(stbtt_uint8 *s1, stbtt_int32 len1, stbtt_uint8 *s2, stbtt_int32 len2)
+ {
+    stbtt_int32 i=0;
+ 
+@@ -3089,9 +4812,9 @@ static stbtt_int32 stbtt__CompareUTF8toUTF16_bigendian_prefix(const stbtt_uint8
+    return i;
+ }
+ 
+-STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2) 
++static int stbtt_CompareUTF8toUTF16_bigendian_internal(char *s1, int len1, char *s2, int len2)
+ {
+-   return len1 == stbtt__CompareUTF8toUTF16_bigendian_prefix((const stbtt_uint8*) s1, len1, (const stbtt_uint8*) s2, len2);
++   return len1 == stbtt__CompareUTF8toUTF16_bigendian_prefix((stbtt_uint8*) s1, len1, (stbtt_uint8*) s2, len2);
+ }
+ 
+ // returns results in whatever encoding you request... but note that 2-byte encodings
+@@ -3147,7 +4870,7 @@ static int stbtt__matchpair(stbtt_uint8 *fc, stbtt_uint32 nm, stbtt_uint8 *name,
+                         return 1;
+                   } else if (matchlen < nlen && name[matchlen] == ' ') {
+                      ++matchlen;
+-                     if (stbtt_CompareUTF8toUTF16_bigendian((char*) (name+matchlen), nlen-matchlen, (char*)(fc+stringOffset+off),slen))
++                     if (stbtt_CompareUTF8toUTF16_bigendian_internal((char*) (name+matchlen), nlen-matchlen, (char*)(fc+stringOffset+off),slen))
+                         return 1;
+                   }
+                } else {
+@@ -3193,7 +4916,7 @@ static int stbtt__matches(stbtt_uint8 *fc, stbtt_uint32 offset, stbtt_uint8 *nam
+    return 0;
+ }
+ 
+-STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *font_collection, const char *name_utf8, stbtt_int32 flags)
++static int stbtt_FindMatchingFont_internal(unsigned char *font_collection, char *name_utf8, stbtt_int32 flags)
+ {
+    stbtt_int32 i;
+    for (i=0;;++i) {
+@@ -3204,11 +4927,71 @@ STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *font_collection, const
+    }
+ }
+ 
++#if defined(__GNUC__) || defined(__clang__)
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-qual"
++#endif
++
++STBTT_DEF int stbtt_BakeFontBitmap(const unsigned char *data, int offset,
++                                float pixel_height, unsigned char *pixels, int pw, int ph,
++                                int first_char, int num_chars, stbtt_bakedchar *chardata)
++{
++   return stbtt_BakeFontBitmap_internal((unsigned char *) data, offset, pixel_height, pixels, pw, ph, first_char, num_chars, chardata);
++}
++
++STBTT_DEF int stbtt_GetFontOffsetForIndex(const unsigned char *data, int index)
++{
++   return stbtt_GetFontOffsetForIndex_internal((unsigned char *) data, index);
++}
++
++STBTT_DEF int stbtt_GetNumberOfFonts(const unsigned char *data)
++{
++   return stbtt_GetNumberOfFonts_internal((unsigned char *) data);
++}
++
++STBTT_DEF int stbtt_InitFont(stbtt_fontinfo *info, const unsigned char *data, int offset)
++{
++   return stbtt_InitFont_internal(info, (unsigned char *) data, offset);
++}
++
++STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *fontdata, const char *name, int flags)
++{
++   return stbtt_FindMatchingFont_internal((unsigned char *) fontdata, (char *) name, flags);
++}
++
++STBTT_DEF int stbtt_CompareUTF8toUTF16_bigendian(const char *s1, int len1, const char *s2, int len2)
++{
++   return stbtt_CompareUTF8toUTF16_bigendian_internal((char *) s1, len1, (char *) s2, len2);
++}
++
++#if defined(__GNUC__) || defined(__clang__)
++#pragma GCC diagnostic pop
++#endif
++
+ #endif // STB_TRUETYPE_IMPLEMENTATION
+ 
+ 
+ // FULL VERSION HISTORY
+ //
++//   1.25 (2021-07-11) many fixes
++//   1.24 (2020-02-05) fix warning
++//   1.23 (2020-02-02) query SVG data for glyphs; query whole kerning table (but only kern not GPOS)
++//   1.22 (2019-08-11) minimize missing-glyph duplication; fix kerning if both 'GPOS' and 'kern' are defined
++//   1.21 (2019-02-25) fix warning
++//   1.20 (2019-02-07) PackFontRange skips missing codepoints; GetScaleFontVMetrics()
++//   1.19 (2018-02-11) OpenType GPOS kerning (horizontal only), STBTT_fmod
++//   1.18 (2018-01-29) add missing function
++//   1.17 (2017-07-23) make more arguments const; doc fix
++//   1.16 (2017-07-12) SDF support
++//   1.15 (2017-03-03) make more arguments const
++//   1.14 (2017-01-16) num-fonts-in-TTC function
++//   1.13 (2017-01-02) support OpenType fonts, certain Apple fonts
++//   1.12 (2016-10-25) suppress warnings about casting away const with -Wcast-qual
++//   1.11 (2016-04-02) fix unused-variable warning
++//   1.10 (2016-04-02) allow user-defined fabs() replacement
++//                     fix memory leak if fontsize=0.0
++//                     fix warning from duplicate typedef
++//   1.09 (2016-01-16) warning fix; avoid crash on outofmem; use alloc userdata for PackFontRanges
+ //   1.08 (2015-09-13) document stbtt_Rasterize(); fixes for vertical & horizontal edges
+ //   1.07 (2015-08-01) allow PackFontRanges to accept arrays of sparse codepoints;
+ //                     allow PackFontRanges to pack and render in separate phases;
+@@ -3250,3 +5033,45 @@ STBTT_DEF int stbtt_FindMatchingFont(const unsigned char *font_collection, const
+ //   0.2  (2009-03-11) Fix unsigned/signed char warnings
+ //   0.1  (2009-03-09) First public release
+ //
++
++/*
++------------------------------------------------------------------------------
++This software is available under 2 licenses -- choose whichever you prefer.
++------------------------------------------------------------------------------
++ALTERNATIVE A - MIT License
++Copyright (c) 2017 Sean Barrett
++Permission is hereby granted, free of charge, to any person obtaining a copy of
++this software and associated documentation files (the "Software"), to deal in
++the Software without restriction, including without limitation the rights to
++use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
++of the Software, and to permit persons to whom the Software is furnished to do
++so, subject to the following conditions:
++The above copyright notice and this permission notice shall be included in all
++copies or substantial portions of the Software.
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++SOFTWARE.
++------------------------------------------------------------------------------
++ALTERNATIVE B - Public Domain (www.unlicense.org)
++This is free and unencumbered software released into the public domain.
++Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
++software, either in source code form or as a compiled binary, for any purpose,
++commercial or non-commercial, and by any means.
++In jurisdictions that recognize copyright laws, the author or authors of this
++software dedicate any and all copyright interest in the software to the public
++domain. We make this dedication for the benefit of the public at large and to
++the detriment of our heirs and successors. We intend this dedication to be an
++overt act of relinquishment in perpetuity of all present and future rights to
++this software under copyright law.
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
++ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
++WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++------------------------------------------------------------------------------
++*/
+diff --git a/test/dm/video.c b/test/dm/video.c
+index 6d9c55c14035..0534ee93a3d4 100644
+--- a/test/dm/video.c
++++ b/test/dm/video.c
+@@ -556,7 +556,7 @@ static int dm_test_video_truetype(struct unit_test_state *uts)
+ 	ut_assertok(video_get_nologo(uts, &dev));
+ 	ut_assertok(uclass_get_device(UCLASS_VIDEO_CONSOLE, 0, &con));
+ 	vidconsole_put_string(con, test_string);
+-	ut_asserteq(12187, compress_frame_buffer(uts, dev));
++	ut_asserteq(12174, compress_frame_buffer(uts, dev));
+ 
+ 	return 0;
+ }
+@@ -577,7 +577,7 @@ static int dm_test_video_truetype_scroll(struct unit_test_state *uts)
+ 	ut_assertok(video_get_nologo(uts, &dev));
+ 	ut_assertok(uclass_get_device(UCLASS_VIDEO_CONSOLE, 0, &con));
+ 	vidconsole_put_string(con, test_string);
+-	ut_asserteq(34481, compress_frame_buffer(uts, dev));
++	ut_asserteq(34287, compress_frame_buffer(uts, dev));
+ 
+ 	return 0;
+ }
+@@ -598,7 +598,7 @@ static int dm_test_video_truetype_bs(struct unit_test_state *uts)
+ 	ut_assertok(video_get_nologo(uts, &dev));
+ 	ut_assertok(uclass_get_device(UCLASS_VIDEO_CONSOLE, 0, &con));
+ 	vidconsole_put_string(con, test_string);
+-	ut_asserteq(29579, compress_frame_buffer(uts, dev));
++	ut_asserteq(29471, compress_frame_buffer(uts, dev));
+ 
+ 	return 0;
+ }

--- a/apple-silicon-support/packages/uboot-asahi/0ab4f91a107832692781a367a1ef2173af75f108.patch
+++ b/apple-silicon-support/packages/uboot-asahi/0ab4f91a107832692781a367a1ef2173af75f108.patch
@@ -1,0 +1,198 @@
+From 0ab4f91a107832692781a367a1ef2173af75f108 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Thu, 1 Jun 2023 10:22:33 -0600
+Subject: [PATCH] video: Provide a way to clear part of the console
+
+This is useful when the background colour must be written before text
+is updated, to avoid strange display artifacts.
+
+Add a function for this, using the existing code from the truetype
+console.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c | 72 ++------------------------------
+ drivers/video/video-uclass.c     | 52 +++++++++++++++++++++++
+ include/video.h                  | 16 +++++++
+ 3 files changed, 71 insertions(+), 69 deletions(-)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 0ea8a9f6215e..63d7557c71a0 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -378,72 +378,6 @@ static int console_truetype_putc_xy(struct udevice *dev, uint x, uint y,
+ 	return width_frac;
+ }
+ 
+-/**
+- * console_truetype_erase() - Erase a character
+- *
+- * This is used for backspace. We erase a square of the display within the
+- * given bounds.
+- *
+- * @dev:	Device to update
+- * @xstart:	X start position in pixels from the left
+- * @ystart:	Y start position in pixels from the top
+- * @xend:	X end position in pixels from the left
+- * @yend:	Y end position  in pixels from the top
+- * @clr:	Value to write
+- * Return: 0 if OK, -ENOSYS if the display depth is not supported
+- */
+-static int console_truetype_erase(struct udevice *dev, int xstart, int ystart,
+-				  int xend, int yend, int clr)
+-{
+-	struct video_priv *vid_priv = dev_get_uclass_priv(dev->parent);
+-	void *start, *line;
+-	int pixels = xend - xstart;
+-	int row, i, ret;
+-
+-	start = vid_priv->fb + ystart * vid_priv->line_length;
+-	start += xstart * VNBYTES(vid_priv->bpix);
+-	line = start;
+-	for (row = ystart; row < yend; row++) {
+-		switch (vid_priv->bpix) {
+-		case VIDEO_BPP8: {
+-			uint8_t *dst = line;
+-
+-			if (IS_ENABLED(CONFIG_VIDEO_BPP8)) {
+-				for (i = 0; i < pixels; i++)
+-					*dst++ = clr;
+-			}
+-			break;
+-		}
+-		case VIDEO_BPP16: {
+-			uint16_t *dst = line;
+-
+-			if (IS_ENABLED(CONFIG_VIDEO_BPP16)) {
+-				for (i = 0; i < pixels; i++)
+-					*dst++ = clr;
+-			}
+-			break;
+-		}
+-		case VIDEO_BPP32: {
+-			uint32_t *dst = line;
+-
+-			if (IS_ENABLED(CONFIG_VIDEO_BPP32)) {
+-				for (i = 0; i < pixels; i++)
+-					*dst++ = clr;
+-			}
+-			break;
+-		}
+-		default:
+-			return -ENOSYS;
+-		}
+-		line += vid_priv->line_length;
+-	}
+-	ret = vidconsole_sync_copy(dev, start, line);
+-	if (ret)
+-		return ret;
+-
+-	return 0;
+-}
+-
+ /**
+  * console_truetype_backspace() - Handle a backspace operation
+  *
+@@ -482,9 +416,9 @@ static int console_truetype_backspace(struct udevice *dev)
+ 	else
+ 		xend = vid_priv->xsize;
+ 
+-	console_truetype_erase(dev, VID_TO_PIXEL(pos->xpos_frac), pos->ypos,
+-			       xend, pos->ypos + vc_priv->y_charsize,
+-			       vid_priv->colour_bg);
++	video_fill_part(vid_dev, VID_TO_PIXEL(pos->xpos_frac), pos->ypos,
++			xend, pos->ypos + vc_priv->y_charsize,
++			vid_priv->colour_bg);
+ 
+ 	/* Move the cursor back to where it was when we pushed this record */
+ 	vc_priv->xcur_frac = pos->xpos_frac;
+diff --git a/drivers/video/video-uclass.c b/drivers/video/video-uclass.c
+index 1b66a8061a74..d304e92c2441 100644
+--- a/drivers/video/video-uclass.c
++++ b/drivers/video/video-uclass.c
+@@ -142,6 +142,58 @@ int video_reserve(ulong *addrp)
+ 	return 0;
+ }
+ 
++int video_fill_part(struct udevice *dev, int xstart, int ystart, int xend,
++		    int yend, u32 colour)
++{
++	struct video_priv *priv = dev_get_uclass_priv(dev);
++	void *start, *line;
++	int pixels = xend - xstart;
++	int row, i, ret;
++
++	start = priv->fb + ystart * priv->line_length;
++	start += xstart * VNBYTES(priv->bpix);
++	line = start;
++	for (row = ystart; row < yend; row++) {
++		switch (priv->bpix) {
++		case VIDEO_BPP8: {
++			u8 *dst = line;
++
++			if (IS_ENABLED(CONFIG_VIDEO_BPP8)) {
++				for (i = 0; i < pixels; i++)
++					*dst++ = colour;
++			}
++			break;
++		}
++		case VIDEO_BPP16: {
++			u16 *dst = line;
++
++			if (IS_ENABLED(CONFIG_VIDEO_BPP16)) {
++				for (i = 0; i < pixels; i++)
++					*dst++ = colour;
++			}
++			break;
++		}
++		case VIDEO_BPP32: {
++			u32 *dst = line;
++
++			if (IS_ENABLED(CONFIG_VIDEO_BPP32)) {
++				for (i = 0; i < pixels; i++)
++					*dst++ = colour;
++			}
++			break;
++		}
++		default:
++			return -ENOSYS;
++		}
++		line += priv->line_length;
++	}
++	ret = video_sync_copy(dev, start, line);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
+ int video_fill(struct udevice *dev, u32 colour)
+ {
+ 	struct video_priv *priv = dev_get_uclass_priv(dev);
+diff --git a/include/video.h b/include/video.h
+index 03434a81234f..6dc42d464b0b 100644
+--- a/include/video.h
++++ b/include/video.h
+@@ -204,6 +204,22 @@ int video_clear(struct udevice *dev);
+  */
+ int video_fill(struct udevice *dev, u32 colour);
+ 
++/**
++ * video_fill_part() - Erase a region
++ *
++ * Erase a rectangle of the display within the given bounds.
++ *
++ * @dev:	Device to update
++ * @xstart:	X start position in pixels from the left
++ * @ystart:	Y start position in pixels from the top
++ * @xend:	X end position in pixels from the left
++ * @yend:	Y end position  in pixels from the top
++ * @colour:	Value to write
++ * Return: 0 if OK, -ENOSYS if the display depth is not supported
++ */
++int video_fill_part(struct udevice *dev, int xstart, int ystart, int xend,
++		    int yend, u32 colour);
++
+ /**
+  * video_sync() - Sync a device's frame buffer with its hardware
+  *

--- a/apple-silicon-support/packages/uboot-asahi/37db20d0a64132a7ae3d0223de6b93167d60bea4.patch
+++ b/apple-silicon-support/packages/uboot-asahi/37db20d0a64132a7ae3d0223de6b93167d60bea4.patch
@@ -1,0 +1,359 @@
+From 37db20d0a64132a7ae3d0223de6b93167d60bea4 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Sun, 1 Oct 2023 19:13:21 -0600
+Subject: [PATCH] video: Support showing a cursor
+
+Add rudimentary support for displaying a cursor on a vidconsole. This
+helps the user to see where text is being entered.
+
+The implementation so far is very simple: the cursor is just a vertical
+bar of fixed width and cannot be erased. To erase the cursor, the text
+must be redrawn over it.
+
+This is good enough for expo but will need enhancement to be useful for
+the command-line console. For example, it could save and restore the
+area behind the cursor.
+
+For now, enable this only for expo, to reduce code size.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_core.c        |  31 +++++++++
+ drivers/video/console_normal.c      |  29 ++++++++
+ drivers/video/console_truetype.c    | 103 ++++++++++++++++++++++++++++
+ drivers/video/vidconsole-uclass.c   |  15 ++++
+ drivers/video/vidconsole_internal.h |  24 +++++++
+ include/video_console.h             |  35 ++++++++++
+ 6 files changed, 237 insertions(+)
+
+diff --git a/drivers/video/console_core.c b/drivers/video/console_core.c
+index b5d0e3dceca3..d17764d0b086 100644
+--- a/drivers/video/console_core.c
++++ b/drivers/video/console_core.c
+@@ -176,6 +176,37 @@ int fill_char_horizontally(uchar *pfont, void **line, struct video_priv *vid_pri
+ 	return ret;
+ }
+ 
++int draw_cursor_vertically(void **line, struct video_priv *vid_priv,
++			   uint height, bool direction)
++{
++	int step, line_step, pbytes, ret;
++	uint value;
++	void *dst;
++
++	ret = check_bpix_support(vid_priv->bpix);
++	if (ret)
++		return ret;
++
++	pbytes = VNBYTES(vid_priv->bpix);
++	if (direction) {
++		step = -pbytes;
++		line_step = -vid_priv->line_length;
++	} else {
++		step = pbytes;
++		line_step = vid_priv->line_length;
++	}
++
++	value = vid_priv->colour_fg;
++
++	for (int row = 0; row < height; row++) {
++		dst = *line;
++		for (int col = 0; col < VIDCONSOLE_CURSOR_WIDTH; col++)
++			fill_pixel_and_goto_next(&dst, value, pbytes, step);
++		*line += line_step;
++	}
++	return ret;
++}
++
+ int console_probe(struct udevice *dev)
+ {
+ 	return console_set_font(dev, fonts);
+diff --git a/drivers/video/console_normal.c b/drivers/video/console_normal.c
+index 413c7abee9e1..a0231293f311 100644
+--- a/drivers/video/console_normal.c
++++ b/drivers/video/console_normal.c
+@@ -97,6 +97,34 @@ static int console_putc_xy(struct udevice *dev, uint x_frac, uint y, char ch)
+ 	return VID_TO_POS(fontdata->width);
+ }
+ 
++static int console_set_cursor_visible(struct udevice *dev, bool visible,
++				      uint x, uint y, uint index)
++{
++	struct vidconsole_priv *vc_priv = dev_get_uclass_priv(dev);
++	struct udevice *vid = dev->parent;
++	struct video_priv *vid_priv = dev_get_uclass_priv(vid);
++	struct console_simple_priv *priv = dev_get_priv(dev);
++	struct video_fontdata *fontdata = priv->fontdata;
++	int pbytes = VNBYTES(vid_priv->bpix);
++	void *start, *line;
++
++	/* for now, this is not used outside expo */
++	if (!IS_ENABLED(CONFIG_EXPO))
++		return -ENOSYS;
++
++	x += index * fontdata->width;
++	start = vid_priv->fb + y * vid_priv->line_length + x * pbytes;
++
++	/* place the cursor 1 pixel before the start of the next char */
++	x -= 1;
++
++	line = start;
++	draw_cursor_vertically(&line, vid_priv, vc_priv->y_charsize,
++			       NORMAL_DIRECTION);
++
++	return 0;
++}
++
+ struct vidconsole_ops console_ops = {
+ 	.putc_xy	= console_putc_xy,
+ 	.move_rows	= console_move_rows,
+@@ -104,6 +132,7 @@ struct vidconsole_ops console_ops = {
+ 	.get_font_size	= console_simple_get_font_size,
+ 	.get_font	= console_simple_get_font,
+ 	.select_font	= console_simple_select_font,
++	.set_cursor_visible	= console_set_cursor_visible,
+ };
+ 
+ U_BOOT_DRIVER(vidconsole_normal) = {
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 1ce01a96bb6c..242b8b71342d 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -831,6 +831,108 @@ static int truetype_entry_restore(struct udevice *dev, struct abuf *buf)
+ 	return 0;
+ }
+ 
++static int truetype_set_cursor_visible(struct udevice *dev, bool visible,
++				       uint x, uint y, uint index)
++{
++	struct vidconsole_priv *vc_priv = dev_get_uclass_priv(dev);
++	struct udevice *vid = dev->parent;
++	struct video_priv *vid_priv = dev_get_uclass_priv(vid);
++	struct console_tt_priv *priv = dev_get_priv(dev);
++	struct console_tt_metrics *met = priv->cur_met;
++	uint row, width, height, xoff;
++	void *start, *line;
++	uint out, val;
++	int ret;
++
++	if (!visible)
++		return 0;
++
++	/*
++	 * figure out where to place the cursor. This driver ignores the
++	 * passed-in values, since an entry_restore() must have been done before
++	 * calling this function.
++	 */
++	if (index < priv->pos_ptr)
++		x = VID_TO_PIXEL(priv->pos[index].xpos_frac);
++	else
++		x = VID_TO_PIXEL(vc_priv->xcur_frac);
++
++	y = vc_priv->ycur;
++	height = met->font_size;
++	xoff = 0;
++
++	val = vid_priv->colour_bg ? 0 : 255;
++	width = VIDCONSOLE_CURSOR_WIDTH;
++
++	/* Figure out where to write the cursor in the frame buffer */
++	start = vid_priv->fb + y * vid_priv->line_length +
++		x * VNBYTES(vid_priv->bpix);
++	line = start;
++
++	/* draw a vertical bar in the correct position */
++	for (row = 0; row < height; row++) {
++		switch (vid_priv->bpix) {
++		case VIDEO_BPP8:
++			if (IS_ENABLED(CONFIG_VIDEO_BPP8)) {
++				u8 *dst = line + xoff;
++				int i;
++
++				out = val;
++				for (i = 0; i < width; i++) {
++					if (vid_priv->colour_fg)
++						*dst++ |= out;
++					else
++						*dst++ &= out;
++				}
++			}
++			break;
++		case VIDEO_BPP16: {
++			u16 *dst = (u16 *)line + xoff;
++			int i;
++
++			if (IS_ENABLED(CONFIG_VIDEO_BPP16)) {
++				for (i = 0; i < width; i++) {
++					out = val >> 3 |
++						(val >> 2) << 5 |
++						(val >> 3) << 11;
++					if (vid_priv->colour_fg)
++						*dst++ |= out;
++					else
++						*dst++ &= out;
++				}
++			}
++			break;
++		}
++		case VIDEO_BPP32: {
++			u32 *dst = (u32 *)line + xoff;
++			int i;
++
++			if (IS_ENABLED(CONFIG_VIDEO_BPP32)) {
++				for (i = 0; i < width; i++) {
++					int out;
++
++					out = val | val << 8 | val << 16;
++					if (vid_priv->colour_fg)
++						*dst++ |= out;
++					else
++						*dst++ &= out;
++				}
++			}
++			break;
++		}
++		default:
++			return -ENOSYS;
++		}
++
++		line += vid_priv->line_length;
++	}
++	ret = vidconsole_sync_copy(dev, start, line);
++	if (ret)
++		return ret;
++
++	return video_sync(vid, true);
++}
++
+ const char *console_truetype_get_font_size(struct udevice *dev, uint *sizep)
+ {
+ 	struct console_tt_priv *priv = dev_get_priv(dev);
+@@ -886,6 +988,7 @@ struct vidconsole_ops console_truetype_ops = {
+ 	.nominal	= truetype_nominal,
+ 	.entry_save	= truetype_entry_save,
+ 	.entry_restore	= truetype_entry_restore,
++	.set_cursor_visible	= truetype_set_cursor_visible
+ };
+ 
+ U_BOOT_DRIVER(vidconsole_truetype) = {
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index 2f3f685a55c9..22d55df71f63 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -672,6 +672,21 @@ int vidconsole_entry_restore(struct udevice *dev, struct abuf *buf)
+ 	return 0;
+ }
+ 
++int vidconsole_set_cursor_visible(struct udevice *dev, bool visible,
++				  uint x, uint y, uint index)
++{
++	struct vidconsole_ops *ops = vidconsole_get_ops(dev);
++	int ret;
++
++	if (ops->set_cursor_visible) {
++		ret = ops->set_cursor_visible(dev, visible, x, y, index);
++		if (ret != -ENOSYS)
++			return ret;
++	}
++
++	return 0;
++}
++
+ void vidconsole_push_colour(struct udevice *dev, enum colour_idx fg,
+ 			    enum colour_idx bg, struct vidconsole_colour *old)
+ {
+diff --git a/drivers/video/vidconsole_internal.h b/drivers/video/vidconsole_internal.h
+index c41edd45249a..0ec581b26638 100644
+--- a/drivers/video/vidconsole_internal.h
++++ b/drivers/video/vidconsole_internal.h
+@@ -92,6 +92,30 @@ int fill_char_vertically(uchar *pfont, void **line, struct video_priv *vid_priv,
+ int fill_char_horizontally(uchar *pfont, void **line, struct video_priv *vid_priv,
+ 			   struct video_fontdata *fontdata, bool direction);
+ 
++/**
++ * draw_cursor_vertically() - Draw a simple vertical cursor
++ *
++ * @line: pointer to framebuffer buffer: upper left cursor corner
++ * @vid_priv: driver private data
++ * @height: height of the cursor in pixels
++ * @param direction	controls cursor orientation. Can be normal or flipped.
++ * When normal:               When flipped:
++ *|-----------------------------------------------|
++ *|               *        |   line stepping      |
++ *|    ^  * * * * *        |   |                  |
++ *|    |    *     *        |   v   *     *        |
++ *|    |                   |       * * * * *      |
++ *|  line stepping         |       *              |
++ *|                        |                      |
++ *|  stepping ->           |        <<- stepping  |
++ *|---!!we're starting from upper left char corner|
++ *|-----------------------------------------------|
++ *
++ * Return: 0, if success, or else error code.
++ */
++int draw_cursor_vertically(void **line, struct video_priv *vid_priv,
++			   uint height, bool direction);
++
+ /**
+  * console probe function.
+  *
+diff --git a/include/video_console.h b/include/video_console.h
+index 87f9a588575d..bde67fa9a5a9 100644
+--- a/include/video_console.h
++++ b/include/video_console.h
+@@ -16,6 +16,11 @@ struct video_priv;
+ #define VID_TO_PIXEL(x)	((x) / VID_FRAC_DIV)
+ #define VID_TO_POS(x)	((x) * VID_FRAC_DIV)
+ 
++enum {
++	/* cursor width in pixels */
++	VIDCONSOLE_CURSOR_WIDTH		= 2,
++};
++
+ /**
+  * struct vidconsole_priv - uclass-private data about a console device
+  *
+@@ -264,6 +269,21 @@ struct vidconsole_ops {
+ 	 * Return: 0 if OK, -ve on error
+ 	 */
+ 	int (*entry_restore)(struct udevice *dev, struct abuf *buf);
++
++	/**
++	 * set_cursor_visible() - Show or hide the cursor
++	 *
++	 * Shows or hides a cursor at the current position
++	 *
++	 * @dev: Console device to use
++	 * @visible: true to show the cursor, false to hide it
++	 * @x: X position in pixels
++	 * @y: Y position in pixels
++	 * @index: Character position (0 = at start)
++	 * Return: 0 if OK, -ve on error
++	 */
++	int (*set_cursor_visible)(struct udevice *dev, bool visible,
++				  uint x, uint y, uint index);
+ };
+ 
+ /* Get a pointer to the driver operations for a video console device */
+@@ -342,6 +362,21 @@ int vidconsole_entry_save(struct udevice *dev, struct abuf *buf);
+  */
+ int vidconsole_entry_restore(struct udevice *dev, struct abuf *buf);
+ 
++/**
++ * vidconsole_set_cursor_visible() - Show or hide the cursor
++ *
++ * Shows or hides a cursor at the current position
++ *
++ * @dev: Console device to use
++ * @visible: true to show the cursor, false to hide it
++ * @x: X position in pixels
++ * @y: Y position in pixels
++ * @index: Character position (0 = at start)
++ * Return: 0 if OK, -ve on error
++ */
++int vidconsole_set_cursor_visible(struct udevice *dev, bool visible,
++				  uint x, uint y, uint index);
++
+ /**
+  * vidconsole_push_colour() - Temporarily change the font colour
+  *

--- a/apple-silicon-support/packages/uboot-asahi/477c92689a374f13e5792a0216509b6696798c29.patch
+++ b/apple-silicon-support/packages/uboot-asahi/477c92689a374f13e5792a0216509b6696798c29.patch
@@ -1,0 +1,35 @@
+From 477c92689a374f13e5792a0216509b6696798c29 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Thu, 11 Jan 2024 00:48:12 +0100
+Subject: [PATCH] video: simplefb: HACK: Set video font size
+
+Request the 16x32 font for display resolutions strictly larger than
+FullHD.
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ drivers/video/simplefb.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/video/simplefb.c b/drivers/video/simplefb.c
+index 235ec761f70..502b7e7a0ce 100644
+--- a/drivers/video/simplefb.c
++++ b/drivers/video/simplefb.c
+@@ -71,6 +71,17 @@ static int simple_video_probe(struct udevice *dev)
+ 		return -EINVAL;
+ 	}
+ 
++	/* Apple silicon specific hack, should calculate DPI from "panel"
++	 * phandle reference.
++	 */
++	if (uc_priv->xsize > 1920 && uc_priv->ysize > 1080)
++		uc_priv->font_size = 32;
++	/*
++	panel_node = fdtdec_lookup_phandle(blob_, node, "panel");
++	if (panel_node > 0) {
++		uint dpi = fdtdec_get_uint(blob, node, "width-mm");
++	}
++	*/
+ 	return 0;
+ }
+ 

--- a/apple-silicon-support/packages/uboot-asahi/617d7b545b6fa555f47944a10b1a1b261491e3b9.patch
+++ b/apple-silicon-support/packages/uboot-asahi/617d7b545b6fa555f47944a10b1a1b261491e3b9.patch
@@ -1,0 +1,50 @@
+From 617d7b545b6fa555f47944a10b1a1b261491e3b9 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Sun, 1 Oct 2023 19:13:20 -0600
+Subject: [PATCH] video: Export vidconsole_entry_start()
+
+At present this is called only when a newline is detected, since this
+indicates the start of a line of text being entered.
+
+Export this function so it can be used by expo, which may start a new
+text line itself, without first writing out a newline.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/vidconsole-uclass.c | 2 +-
+ include/video_console.h           | 9 +++++++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index 07427ba346b0..2f3f685a55c9 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -48,7 +48,7 @@ int vidconsole_set_row(struct udevice *dev, uint row, int clr)
+ 	return ops->set_row(dev, row, clr);
+ }
+ 
+-static int vidconsole_entry_start(struct udevice *dev)
++int vidconsole_entry_start(struct udevice *dev)
+ {
+ 	struct vidconsole_ops *ops = vidconsole_get_ops(dev);
+ 
+diff --git a/include/video_console.h b/include/video_console.h
+index 28d65451889a..87f9a588575d 100644
+--- a/include/video_console.h
++++ b/include/video_console.h
+@@ -399,6 +399,15 @@ int vidconsole_move_rows(struct udevice *dev, uint rowdst, uint rowsrc,
+  */
+ int vidconsole_set_row(struct udevice *dev, uint row, int clr);
+ 
++/**
++ * vidconsole_entry_start() - Set the start position of a vidconsole line
++ *
++ * Marks the current cursor position as the start of a line
++ *
++ * @dev:	Device to adjust
++ */
++int vidconsole_entry_start(struct udevice *dev);
++
+ /**
+  * vidconsole_put_char() - Output a character to the current console position
+  *

--- a/apple-silicon-support/packages/uboot-asahi/648a4991d0713af656a2fa50ec8e708c2beb044e.patch
+++ b/apple-silicon-support/packages/uboot-asahi/648a4991d0713af656a2fa50ec8e708c2beb044e.patch
@@ -1,0 +1,93 @@
+From 648a4991d0713af656a2fa50ec8e708c2beb044e Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Thu, 1 Jun 2023 10:22:45 -0600
+Subject: [PATCH] video: Allow temporary colour changes
+
+It is sometimes necessary to highlight some text in a different colour.
+Add an easy way to do this and then restore the original console colours.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/vidconsole-uclass.c | 20 ++++++++++++++++++++
+ include/video_console.h           | 30 ++++++++++++++++++++++++++++++
+ 2 files changed, 50 insertions(+)
+
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index a21fde0e1d46..3f89537c47b7 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -596,6 +596,26 @@ int vidconsole_select_font(struct udevice *dev, const char *name, uint size)
+ 	return ops->select_font(dev, name, size);
+ }
+ 
++void vidconsole_push_colour(struct udevice *dev, enum colour_idx fg,
++			    enum colour_idx bg, struct vidconsole_colour *old)
++{
++	struct video_priv *vid_priv = dev_get_uclass_priv(dev->parent);
++
++	old->colour_fg = vid_priv->colour_fg;
++	old->colour_bg = vid_priv->colour_bg;
++
++	vid_priv->colour_fg = video_index_to_colour(vid_priv, fg);
++	vid_priv->colour_bg = video_index_to_colour(vid_priv, bg);
++}
++
++void vidconsole_pop_colour(struct udevice *dev, struct vidconsole_colour *old)
++{
++	struct video_priv *vid_priv = dev_get_uclass_priv(dev->parent);
++
++	vid_priv->colour_fg = old->colour_fg;
++	vid_priv->colour_bg = old->colour_bg;
++}
++
+ /* Set up the number of rows and colours (rotated drivers override this) */
+ static int vidconsole_pre_probe(struct udevice *dev)
+ {
+diff --git a/include/video_console.h b/include/video_console.h
+index 3db9a7e1fb95..81d4c4d874df 100644
+--- a/include/video_console.h
++++ b/include/video_console.h
+@@ -71,6 +71,17 @@ struct vidfont_info {
+ 	const char *name;
+ };
+ 
++/**
++ * struct vidconsole_colour - Holds colour information
++ *
++ * @colour_fg:	Foreground colour (pixel value)
++ * @colour_bg:	Background colour (pixel value)
++ */
++struct vidconsole_colour {
++	u32 colour_fg;
++	u32 colour_bg;
++};
++
+ /**
+  * struct vidconsole_ops - Video console operations
+  *
+@@ -204,6 +215,25 @@ int vidconsole_get_font(struct udevice *dev, int seq,
+  */
+ int vidconsole_select_font(struct udevice *dev, const char *name, uint size);
+ 
++/**
++ * vidconsole_push_colour() - Temporarily change the font colour
++ *
++ * @dev:	Device to adjust
++ * @fg:		Foreground colour to select
++ * @bg:		Background colour to select
++ * @old:	Place to store the current colour, so it can be restored
++ */
++void vidconsole_push_colour(struct udevice *dev, enum colour_idx fg,
++			    enum colour_idx bg, struct vidconsole_colour *old);
++
++/**
++ * vidconsole_pop_colour() - Restore the original colour
++ *
++ * @dev:	Device to adjust
++ * @old:	Old colour to be restored
++ */
++void vidconsole_pop_colour(struct udevice *dev, struct vidconsole_colour *old);
++
+ /**
+  * vidconsole_putc_xy() - write a single character to a position
+  *

--- a/apple-silicon-support/packages/uboot-asahi/6524e8095eeefda61c1daca2ffb19224dd65618f.patch
+++ b/apple-silicon-support/packages/uboot-asahi/6524e8095eeefda61c1daca2ffb19224dd65618f.patch
@@ -1,0 +1,26 @@
+From 6524e8095eeefda61c1daca2ffb19224dd65618f Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Wed, 10 Jan 2024 22:59:19 +0100
+Subject: [PATCH] video: console: Fix buffer overflow in cmd 'font list'
+
+vidconsole_ops.get_font is documented to return -ENOENT after the last
+video_fontdata entry.
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ drivers/video/console_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/video/console_core.c b/drivers/video/console_core.c
+index d17764d0b08..939363653f6 100644
+--- a/drivers/video/console_core.c
++++ b/drivers/video/console_core.c
+@@ -225,7 +225,7 @@ int console_simple_get_font(struct udevice *dev, int seq, struct vidfont_info *i
+ {
+ 	info->name = fonts[seq].name;
+ 
+-	return 0;
++	return info->name ? 0 : -ENOENT;
+ }
+ 
+ int console_simple_select_font(struct udevice *dev, const char *name, uint size)

--- a/apple-silicon-support/packages/uboot-asahi/6d225ec0cc5251c540164b4303261d29f0ade644.patch
+++ b/apple-silicon-support/packages/uboot-asahi/6d225ec0cc5251c540164b4303261d29f0ade644.patch
@@ -1,0 +1,27 @@
+From 6d225ec0cc5251c540164b4303261d29f0ade644 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Sun, 1 Oct 2023 19:13:35 -0600
+Subject: [PATCH] video: Mark truetype_measure() static
+
+This function is not used outside this file, so mark it static.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 242b8b71342d..14fb81e9563c 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -718,8 +718,8 @@ static int truetype_select_font(struct udevice *dev, const char *name,
+ 	return 0;
+ }
+ 
+-int truetype_measure(struct udevice *dev, const char *name, uint size,
+-		     const char *text, struct vidconsole_bbox *bbox)
++static int truetype_measure(struct udevice *dev, const char *name, uint size,
++			    const char *text, struct vidconsole_bbox *bbox)
+ {
+ 	struct console_tt_metrics *met;
+ 	stbtt_fontinfo *font;

--- a/apple-silicon-support/packages/uboot-asahi/7432f68c53526980d0a2b2ffd54fe61141bb1178.patch
+++ b/apple-silicon-support/packages/uboot-asahi/7432f68c53526980d0a2b2ffd54fe61141bb1178.patch
@@ -1,0 +1,193 @@
+From 7432f68c53526980d0a2b2ffd54fe61141bb1178 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Thu, 1 Jun 2023 10:22:32 -0600
+Subject: [PATCH] video: Drop #ifdefs from console_truetype
+
+Use if() instead to reduce the number of build paths.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c | 112 +++++++++++++++----------------
+ 1 file changed, 56 insertions(+), 56 deletions(-)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 6b5390136a7a..0ea8a9f6215e 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -154,33 +154,33 @@ static int console_truetype_set_row(struct udevice *dev, uint row, int clr)
+ 	end = line + met->font_size * vid_priv->line_length;
+ 
+ 	switch (vid_priv->bpix) {
+-#ifdef CONFIG_VIDEO_BPP8
+ 	case VIDEO_BPP8: {
+ 		u8 *dst;
+ 
+-		for (dst = line; dst < (u8 *)end; ++dst)
+-			*dst = clr;
++		if (IS_ENABLED(CONFIG_VIDEO_BPP8)) {
++			for (dst = line; dst < (u8 *)end; ++dst)
++				*dst = clr;
++		}
+ 		break;
+ 	}
+-#endif
+-#ifdef CONFIG_VIDEO_BPP16
+ 	case VIDEO_BPP16: {
+ 		u16 *dst = line;
+ 
+-		for (dst = line; dst < (u16 *)end; ++dst)
+-			*dst = clr;
++		if (IS_ENABLED(CONFIG_VIDEO_BPP16)) {
++			for (dst = line; dst < (u16 *)end; ++dst)
++				*dst = clr;
++		}
+ 		break;
+ 	}
+-#endif
+-#ifdef CONFIG_VIDEO_BPP32
+ 	case VIDEO_BPP32: {
+ 		u32 *dst = line;
+ 
+-		for (dst = line; dst < (u32 *)end; ++dst)
+-			*dst = clr;
++		if (IS_ENABLED(CONFIG_VIDEO_BPP32)) {
++			for (dst = line; dst < (u32 *)end; ++dst)
++				*dst = clr;
++		}
+ 		break;
+ 	}
+-#endif
+ 	default:
+ 		return -ENOSYS;
+ 	}
+@@ -317,52 +317,52 @@ static int console_truetype_putc_xy(struct udevice *dev, uint x, uint y,
+ 				end = dst;
+ 			}
+ 			break;
+-#ifdef CONFIG_VIDEO_BPP16
+ 		case VIDEO_BPP16: {
+ 			uint16_t *dst = (uint16_t *)line + xoff;
+ 			int i;
+ 
+-			for (i = 0; i < width; i++) {
+-				int val = *bits;
+-				int out;
+-
+-				if (vid_priv->colour_bg)
+-					val = 255 - val;
+-				out = val >> 3 |
+-					(val >> 2) << 5 |
+-					(val >> 3) << 11;
+-				if (vid_priv->colour_fg)
+-					*dst++ |= out;
+-				else
+-					*dst++ &= out;
+-				bits++;
++			if (IS_ENABLED(CONFIG_VIDEO_BPP16)) {
++				for (i = 0; i < width; i++) {
++					int val = *bits;
++					int out;
++
++					if (vid_priv->colour_bg)
++						val = 255 - val;
++					out = val >> 3 |
++						(val >> 2) << 5 |
++						(val >> 3) << 11;
++					if (vid_priv->colour_fg)
++						*dst++ |= out;
++					else
++						*dst++ &= out;
++					bits++;
++				}
++				end = dst;
+ 			}
+-			end = dst;
+ 			break;
+ 		}
+-#endif
+-#ifdef CONFIG_VIDEO_BPP32
+ 		case VIDEO_BPP32: {
+ 			u32 *dst = (u32 *)line + xoff;
+ 			int i;
+ 
+-			for (i = 0; i < width; i++) {
+-				int val = *bits;
+-				int out;
+-
+-				if (vid_priv->colour_bg)
+-					val = 255 - val;
+-				out = val | val << 8 | val << 16;
+-				if (vid_priv->colour_fg)
+-					*dst++ |= out;
+-				else
+-					*dst++ &= out;
+-				bits++;
++			if (IS_ENABLED(CONFIG_VIDEO_BPP32)) {
++				for (i = 0; i < width; i++) {
++					int val = *bits;
++					int out;
++
++					if (vid_priv->colour_bg)
++						val = 255 - val;
++					out = val | val << 8 | val << 16;
++					if (vid_priv->colour_fg)
++						*dst++ |= out;
++					else
++						*dst++ &= out;
++					bits++;
++				}
++				end = dst;
+ 			}
+-			end = dst;
+ 			break;
+ 		}
+-#endif
+ 		default:
+ 			free(data);
+ 			return -ENOSYS;
+@@ -405,33 +405,33 @@ static int console_truetype_erase(struct udevice *dev, int xstart, int ystart,
+ 	line = start;
+ 	for (row = ystart; row < yend; row++) {
+ 		switch (vid_priv->bpix) {
+-#ifdef CONFIG_VIDEO_BPP8
+ 		case VIDEO_BPP8: {
+ 			uint8_t *dst = line;
+ 
+-			for (i = 0; i < pixels; i++)
+-				*dst++ = clr;
++			if (IS_ENABLED(CONFIG_VIDEO_BPP8)) {
++				for (i = 0; i < pixels; i++)
++					*dst++ = clr;
++			}
+ 			break;
+ 		}
+-#endif
+-#ifdef CONFIG_VIDEO_BPP16
+ 		case VIDEO_BPP16: {
+ 			uint16_t *dst = line;
+ 
+-			for (i = 0; i < pixels; i++)
+-				*dst++ = clr;
++			if (IS_ENABLED(CONFIG_VIDEO_BPP16)) {
++				for (i = 0; i < pixels; i++)
++					*dst++ = clr;
++			}
+ 			break;
+ 		}
+-#endif
+-#ifdef CONFIG_VIDEO_BPP32
+ 		case VIDEO_BPP32: {
+ 			uint32_t *dst = line;
+ 
+-			for (i = 0; i < pixels; i++)
+-				*dst++ = clr;
++			if (IS_ENABLED(CONFIG_VIDEO_BPP32)) {
++				for (i = 0; i < pixels; i++)
++					*dst++ = clr;
++			}
+ 			break;
+ 		}
+-#endif
+ 		default:
+ 			return -ENOSYS;
+ 		}

--- a/apple-silicon-support/packages/uboot-asahi/7a2fee8d29a92eadac3fc656d2686ccd20c24a08.patch
+++ b/apple-silicon-support/packages/uboot-asahi/7a2fee8d29a92eadac3fc656d2686ccd20c24a08.patch
@@ -1,0 +1,32 @@
+From 7a2fee8d29a92eadac3fc656d2686ccd20c24a08 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Thu, 25 May 2023 14:17:15 +0200
+Subject: [PATCH] video: console: Fix default font selection
+
+Some callers expect to call this with NULL font name to select the
+default font (eg. boot/scene.c). Without handling the NULL condition
+U-Boot crashes instead of displaying a bootflow GUI menu.
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+Cc: Anatolij Gustschin <agust@denx.de>
+---
+ drivers/video/console_core.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/video/console_core.c b/drivers/video/console_core.c
+index 1f93b1b85fa5..b5d0e3dceca3 100644
+--- a/drivers/video/console_core.c
++++ b/drivers/video/console_core.c
+@@ -201,6 +201,12 @@ int console_simple_select_font(struct udevice *dev, const char *name, uint size)
+ {
+ 	struct video_fontdata *font;
+ 
++	if (!name) {
++		if (fonts->name)
++			console_set_font(dev, fonts);
++		return 0;
++	}
++
+ 	for (font = fonts; font->name; font++) {
+ 		if (!strcmp(name, font->name)) {
+ 			console_set_font(dev, font);

--- a/apple-silicon-support/packages/uboot-asahi/7c00b80d48cbb28e5f6dfc232c344526e28f7176.patch
+++ b/apple-silicon-support/packages/uboot-asahi/7c00b80d48cbb28e5f6dfc232c344526e28f7176.patch
@@ -1,0 +1,74 @@
+From 7c00b80d48cbb28e5f6dfc232c344526e28f7176 Mon Sep 17 00:00:00 2001
+From: Matthias Schiffer <matthias.schiffer@ew.tq-group.com>
+Date: Fri, 14 Jul 2023 13:24:51 +0200
+Subject: [PATCH] lib/charset: fix u16_strlcat() return value
+
+strlcat returns min(strlen(dest), count)+strlen(src). Make u16_strlcat's
+behaviour the same for consistency.
+
+Fixes: eca08ce94ceb ("lib/charset: add u16_strlcat() function")
+Signed-off-by: Matthias Schiffer <matthias.schiffer@ew.tq-group.com>
+---
+ lib/charset.c     | 8 ++++----
+ test/unicode_ut.c | 8 ++++----
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/lib/charset.c b/lib/charset.c
+index b1842755eb1b..5e4c4f948a4a 100644
+--- a/lib/charset.c
++++ b/lib/charset.c
+@@ -444,14 +444,14 @@ u16 *u16_strdup(const void *src)
+ 
+ size_t u16_strlcat(u16 *dest, const u16 *src, size_t count)
+ {
+-	size_t destlen = u16_strlen(dest);
++	size_t destlen = u16_strnlen(dest, count);
+ 	size_t srclen = u16_strlen(src);
+-	size_t ret = destlen + srclen + 1;
++	size_t ret = destlen + srclen;
+ 
+ 	if (destlen >= count)
+ 		return ret;
+-	if (ret > count)
+-		srclen -= ret - count;
++	if (ret >= count)
++		srclen -= (ret - count + 1);
+ 	memcpy(&dest[destlen], src, 2 * srclen);
+ 	dest[destlen + srclen] = 0x0000;
+ 
+diff --git a/test/unicode_ut.c b/test/unicode_ut.c
+index b27d7116b9ee..a9356e2b60db 100644
+--- a/test/unicode_ut.c
++++ b/test/unicode_ut.c
+@@ -808,12 +808,12 @@ static int unicode_test_u16_strlcat(struct unit_test_state *uts)
+ 	/* dest and src are empty string */
+ 	memset(buf, 0, sizeof(buf));
+ 	ret = u16_strlcat(buf, &null_src, sizeof(buf));
+-	ut_asserteq(1, ret);
++	ut_asserteq(0, ret);
+ 
+ 	/* dest is empty string */
+ 	memset(buf, 0, sizeof(buf));
+ 	ret = u16_strlcat(buf, src, sizeof(buf));
+-	ut_asserteq(5, ret);
++	ut_asserteq(4, ret);
+ 	ut_assert(!unicode_test_u16_strcmp(buf, src, 40));
+ 
+ 	/* src is empty string */
+@@ -821,14 +821,14 @@ static int unicode_test_u16_strlcat(struct unit_test_state *uts)
+ 	buf[39] = 0;
+ 	memcpy(buf, dest, sizeof(dest));
+ 	ret = u16_strlcat(buf, &null_src, sizeof(buf));
+-	ut_asserteq(6, ret);
++	ut_asserteq(5, ret);
+ 	ut_assert(!unicode_test_u16_strcmp(buf, dest, 40));
+ 
+ 	for (i = 0; i <= 40; i++) {
+ 		memset(buf, 0xCD, (sizeof(buf) - sizeof(u16)));
+ 		buf[39] = 0;
+ 		memcpy(buf, dest, sizeof(dest));
+-		expected = 10;
++		expected = min(5, i) + 4;
+ 		ret = u16_strlcat(buf, src, i);
+ 		ut_asserteq(expected, ret);
+ 		if (i <= 6) {

--- a/apple-silicon-support/packages/uboot-asahi/826c4e38d45bf45f214f8bde6928ffb78bb42c66.patch
+++ b/apple-silicon-support/packages/uboot-asahi/826c4e38d45bf45f214f8bde6928ffb78bb42c66.patch
@@ -1,0 +1,27 @@
+From 826c4e38d45bf45f214f8bde6928ffb78bb42c66 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Thu, 11 Jan 2024 21:32:48 +0100
+Subject: [PATCH] configs: apple: Use "vidconsole,serial" as stdout/stderr
+
+efi_console expects this order for querying the size from vidconsole.
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ include/configs/apple.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/configs/apple.h b/include/configs/apple.h
+index 189a84cbc88..701ae43c77a 100644
+--- a/include/configs/apple.h
++++ b/include/configs/apple.h
+@@ -6,8 +6,8 @@
+ /* Environment */
+ #define ENV_DEVICE_SETTINGS \
+ 	"stdin=serial,usbkbd,spikbd,mtpkbd\0" \
+-	"stdout=serial,vidconsole\0" \
+-	"stderr=serial,vidconsole\0"
++	"stdout=vidconsole,serial\0" \
++	"stderr=vidconsole,serial\0"
+ 
+ #if IS_ENABLED(CONFIG_CMD_NVME)
+ 	#define BOOT_TARGET_NVME(func) func(NVME, nvme, 0)

--- a/apple-silicon-support/packages/uboot-asahi/8c9b59982d60847f7514d3367aa8cd0f9e178727.patch
+++ b/apple-silicon-support/packages/uboot-asahi/8c9b59982d60847f7514d3367aa8cd0f9e178727.patch
@@ -1,0 +1,28 @@
+From 8c9b59982d60847f7514d3367aa8cd0f9e178727 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Sat, 9 Dec 2023 13:15:48 +0100
+Subject: [PATCH] arm: apple: rtkit: wait up to 30 seconds for IOP power ack
+
+Fixes NVMe initialization on 8TB SSD devices. Tested on a 8TB M2 Ultra
+Mac Studio.
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ arch/arm/mach-apple/rtkit.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-apple/rtkit.c b/arch/arm/mach-apple/rtkit.c
+index 20152fe8ce2..6567a558cc6 100644
+--- a/arch/arm/mach-apple/rtkit.c
++++ b/arch/arm/mach-apple/rtkit.c
+@@ -409,7 +409,9 @@ int apple_rtkit_boot(struct apple_rtkit *rtk)
+ 	rtk->ap_pwr = APPLE_RTKIT_PWR_STATE_QUIESCED;
+ 
+ 	while (rtk->iop_pwr != APPLE_RTKIT_PWR_STATE_ON) {
+-		ret = apple_rtkit_poll(rtk, TIMEOUT_1SEC_US);
++		ret = apple_rtkit_poll(rtk, 30 * TIMEOUT_1SEC_US);
++		if (ret == -ETIMEDOUT)
++			printf("%s: timed out whiole waiting on IOP_POWER state ack\n", __func__);
+ 		if (ret < 0)
+ 			return ret;
+ 	}

--- a/apple-silicon-support/packages/uboot-asahi/9661d323264927941b1cd858b4bab349ee024c50.patch
+++ b/apple-silicon-support/packages/uboot-asahi/9661d323264927941b1cd858b4bab349ee024c50.patch
@@ -1,0 +1,79 @@
+From 9661d323264927941b1cd858b4bab349ee024c50 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Thu, 4 Jan 2024 08:10:37 -0700
+Subject: [PATCH] video: Correct setting of cursor position
+
+The ANSI codes are not correctly handled at present, in that the
+requested X position is added to the current one.
+
+Correct this and also call vidconsole_entry_start() to start a new text
+line.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+Reviewed-by: Anatolij Gustschin <agust@denx.de>
+---
+ drivers/video/vidconsole-uclass.c | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index 577ca5f66e2..e36f823d744 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -126,6 +126,7 @@ void vidconsole_set_cursor_pos(struct udevice *dev, int x, int y)
+ 	priv->xcur_frac = VID_TO_POS(x);
+ 	priv->xstart_frac = priv->xcur_frac;
+ 	priv->ycur = y;
++	vidconsole_entry_start(dev);
+ }
+ 
+ /**
+@@ -135,8 +136,10 @@ void vidconsole_set_cursor_pos(struct udevice *dev, int x, int y)
+  * @row:	new row
+  * @col:	new column
+  */
+-static void set_cursor_position(struct vidconsole_priv *priv, int row, int col)
++static void set_cursor_position(struct udevice *dev, int row, int col)
+ {
++	struct vidconsole_priv *priv = dev_get_uclass_priv(dev);
++
+ 	/*
+ 	 * Ensure we stay in the bounds of the screen.
+ 	 */
+@@ -145,9 +148,7 @@ static void set_cursor_position(struct vidconsole_priv *priv, int row, int col)
+ 	if (col >= priv->cols)
+ 		col = priv->cols - 1;
+ 
+-	priv->ycur = row * priv->y_charsize;
+-	priv->xcur_frac = priv->xstart_frac +
+-			  VID_TO_POS(col * priv->x_charsize);
++	vidconsole_position_cursor(dev, col, row);
+ }
+ 
+ /**
+@@ -194,7 +195,7 @@ static void vidconsole_escape_char(struct udevice *dev, char ch)
+ 			int row = priv->row_saved;
+ 			int col = priv->col_saved;
+ 
+-			set_cursor_position(priv, row, col);
++			set_cursor_position(dev, row, col);
+ 			priv->escape = 0;
+ 			return;
+ 		}
+@@ -256,7 +257,7 @@ static void vidconsole_escape_char(struct udevice *dev, char ch)
+ 		if (row < 0)
+ 			row = 0;
+ 		/* Right and bottom overflows are handled in the callee. */
+-		set_cursor_position(priv, row, col);
++		set_cursor_position(dev, row, col);
+ 		break;
+ 	}
+ 	case 'H':
+@@ -280,7 +281,7 @@ static void vidconsole_escape_char(struct udevice *dev, char ch)
+ 		if (col)
+ 			--col;
+ 
+-		set_cursor_position(priv, row, col);
++		set_cursor_position(dev, row, col);
+ 
+ 		break;
+ 	}

--- a/apple-silicon-support/packages/uboot-asahi/9899eef2cb41a9cde1dca87f3ddb041e347b177a.patch
+++ b/apple-silicon-support/packages/uboot-asahi/9899eef2cb41a9cde1dca87f3ddb041e347b177a.patch
@@ -1,0 +1,238 @@
+From 9899eef2cb41a9cde1dca87f3ddb041e347b177a Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Sun, 1 Oct 2023 19:13:19 -0600
+Subject: [PATCH] video: Allow saving and restoring text-entry state
+
+Text entry operates within a context which includes quite a bit of
+information. For example, with Truetype fonts, each character in the
+text string has a position stored, so that it is possible to
+backspace to that character. This information is built up as strings
+are drawn on the display.
+
+For the command line, there is just a single context. It is created
+when command-line entry starts and it is destroyed (or at least not
+needed anymore) when the user presses <enter> to enter the command.
+
+By contrast, expo needs to be able to switch in and out of a text-entry
+context, since it is also displaying other objects in the scene.
+
+Add a way to save and restore the entry context for a vidconsole. This
+is only needed for the truetype vidconsole, so add a method for that,
+storing the information in an abuf struct.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c  | 53 +++++++++++++++++++++++++++++++
+ drivers/video/vidconsole-uclass.c | 32 +++++++++++++++++++
+ include/video_console.h           | 49 ++++++++++++++++++++++++++++
+ 3 files changed, 134 insertions(+)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 8ed79c37676c..1ce01a96bb6c 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -4,6 +4,7 @@
+  */
+ 
+ #include <common.h>
++#include <abuf.h>
+ #include <dm.h>
+ #include <log.h>
+ #include <malloc.h>
+@@ -175,6 +176,17 @@ struct console_tt_priv {
+ 	int pos_ptr;
+ };
+ 
++/**
++ * struct console_tt_store - Format used for save/restore of entry information
++ *
++ * @priv: Private data
++ * @cur: Current cursor position
++ */
++struct console_tt_store {
++	struct console_tt_priv priv;
++	struct pos_info cur;
++};
++
+ static int console_truetype_set_row(struct udevice *dev, uint row, int clr)
+ {
+ 	struct video_priv *vid_priv = dev_get_uclass_priv(dev->parent);
+@@ -780,6 +792,45 @@ static int truetype_nominal(struct udevice *dev, const char *name, uint size,
+ 	return 0;
+ }
+ 
++static int truetype_entry_save(struct udevice *dev, struct abuf *buf)
++{
++	struct vidconsole_priv *vc_priv = dev_get_uclass_priv(dev);
++	struct console_tt_priv *priv = dev_get_priv(dev);
++	struct console_tt_store store;
++	const uint size = sizeof(store);
++
++	/*
++	 * store the whole priv structure as it is simpler that picking out
++	 * what we need
++	 */
++	if (!abuf_realloc(buf, size))
++		return log_msg_ret("sav", -ENOMEM);
++
++	store.priv = *priv;
++	store.cur.xpos_frac = vc_priv->xcur_frac;
++	store.cur.ypos  = vc_priv->ycur;
++	memcpy(abuf_data(buf), &store, size);
++
++	return 0;
++}
++
++static int truetype_entry_restore(struct udevice *dev, struct abuf *buf)
++{
++	struct vidconsole_priv *vc_priv = dev_get_uclass_priv(dev);
++	struct console_tt_priv *priv = dev_get_priv(dev);
++	struct console_tt_store store;
++
++	memcpy(&store, abuf_data(buf), sizeof(store));
++
++	vc_priv->xcur_frac = store.cur.xpos_frac;
++	vc_priv->ycur = store.cur.ypos;
++	priv->pos_ptr = store.priv.pos_ptr;
++	memcpy(priv->pos, store.priv.pos,
++	       store.priv.pos_ptr * sizeof(struct pos_info));
++
++	return 0;
++}
++
+ const char *console_truetype_get_font_size(struct udevice *dev, uint *sizep)
+ {
+ 	struct console_tt_priv *priv = dev_get_priv(dev);
+@@ -833,6 +884,8 @@ struct vidconsole_ops console_truetype_ops = {
+ 	.select_font	= truetype_select_font,
+ 	.measure	= truetype_measure,
+ 	.nominal	= truetype_nominal,
++	.entry_save	= truetype_entry_save,
++	.entry_restore	= truetype_entry_restore,
+ };
+ 
+ U_BOOT_DRIVER(vidconsole_truetype) = {
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index 23b1b81731bc..07427ba346b0 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -10,6 +10,7 @@
+ #define LOG_CATEGORY UCLASS_VIDEO_CONSOLE
+ 
+ #include <common.h>
++#include <abuf.h>
+ #include <command.h>
+ #include <console.h>
+ #include <log.h>
+@@ -640,6 +641,37 @@ int vidconsole_nominal(struct udevice *dev, const char *name, uint size,
+ 	return 0;
+ }
+ 
++int vidconsole_entry_save(struct udevice *dev, struct abuf *buf)
++{
++	struct vidconsole_ops *ops = vidconsole_get_ops(dev);
++	int ret;
++
++	if (ops->measure) {
++		ret = ops->entry_save(dev, buf);
++		if (ret != -ENOSYS)
++			return ret;
++	}
++
++	/* no data so make sure the buffer is empty */
++	abuf_realloc(buf, 0);
++
++	return 0;
++}
++
++int vidconsole_entry_restore(struct udevice *dev, struct abuf *buf)
++{
++	struct vidconsole_ops *ops = vidconsole_get_ops(dev);
++	int ret;
++
++	if (ops->measure) {
++		ret = ops->entry_restore(dev, buf);
++		if (ret != -ENOSYS)
++			return ret;
++	}
++
++	return 0;
++}
++
+ void vidconsole_push_colour(struct udevice *dev, enum colour_idx fg,
+ 			    enum colour_idx bg, struct vidconsole_colour *old)
+ {
+diff --git a/include/video_console.h b/include/video_console.h
+index 5234c85efd6f..28d65451889a 100644
+--- a/include/video_console.h
++++ b/include/video_console.h
+@@ -8,6 +8,7 @@
+ 
+ #include <video.h>
+ 
++struct abuf;
+ struct video_priv;
+ 
+ #define VID_FRAC_DIV	256
+@@ -239,6 +240,30 @@ struct vidconsole_ops {
+ 	 */
+ 	int (*nominal)(struct udevice *dev, const char *name, uint size,
+ 		       uint num_chars, struct vidconsole_bbox *bbox);
++
++	/**
++	 * entry_save() - Save any text-entry information for later use
++	 *
++	 * Saves text-entry context such as a list of positions for each
++	 * character in the string.
++	 *
++	 * @dev: Console device to use
++	 * @buf: Buffer to hold saved data
++	 * Return: 0 if OK, -ENOMEM if out of memory
++	 */
++	int (*entry_save)(struct udevice *dev, struct abuf *buf);
++
++	/**
++	 * entry_restore() - Restore text-entry information for current use
++	 *
++	 * Restores text-entry context such as a list of positions for each
++	 * character in the string.
++	 *
++	 * @dev: Console device to use
++	 * @buf: Buffer containing data to restore
++	 * Return: 0 if OK, -ve on error
++	 */
++	int (*entry_restore)(struct udevice *dev, struct abuf *buf);
+ };
+ 
+ /* Get a pointer to the driver operations for a video console device */
+@@ -293,6 +318,30 @@ int vidconsole_measure(struct udevice *dev, const char *name, uint size,
+ int vidconsole_nominal(struct udevice *dev, const char *name, uint size,
+ 		       uint num_chars, struct vidconsole_bbox *bbox);
+ 
++/**
++ * vidconsole_entry_save() - Save any text-entry information for later use
++ *
++ * Saves text-entry context such as a list of positions for each
++ * character in the string.
++ *
++ * @dev: Console device to use
++ * @buf: Buffer to hold saved data
++ * Return: 0 if OK, -ENOMEM if out of memory
++ */
++int vidconsole_entry_save(struct udevice *dev, struct abuf *buf);
++
++/**
++ * entry_restore() - Restore text-entry information for current use
++ *
++ * Restores text-entry context such as a list of positions for each
++ * character in the string.
++ *
++ * @dev: Console device to use
++ * @buf: Buffer containing data to restore
++ * Return: 0 if OK, -ve on error
++ */
++int vidconsole_entry_restore(struct udevice *dev, struct abuf *buf);
++
+ /**
+  * vidconsole_push_colour() - Temporarily change the font colour
+  *

--- a/apple-silicon-support/packages/uboot-asahi/9b425d0b06881e377bef99b3192dba24dcd97e5a.patch
+++ b/apple-silicon-support/packages/uboot-asahi/9b425d0b06881e377bef99b3192dba24dcd97e5a.patch
@@ -1,0 +1,217 @@
+From 9b425d0b06881e377bef99b3192dba24dcd97e5a Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Sat, 13 Jan 2024 18:46:45 +0100
+Subject: [PATCH] video: console: Save and restore fb data under cursor
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ drivers/video/console_core.c        | 95 +++++++++++++++++++++++++++++
+ drivers/video/console_normal.c      |  8 +++
+ drivers/video/vidconsole_internal.h | 41 +++++++++++++
+ 3 files changed, 144 insertions(+)
+
+diff --git a/drivers/video/console_core.c b/drivers/video/console_core.c
+index 939363653f6..f137333f732 100644
+--- a/drivers/video/console_core.c
++++ b/drivers/video/console_core.c
+@@ -9,6 +9,7 @@
+ #include <video.h>
+ #include <video_console.h>
+ #include <dm.h>
++#include <malloc.h>
+ #include <video_font.h>
+ #include "vidconsole_internal.h"
+ 
+@@ -41,6 +42,11 @@ static int console_set_font(struct udevice *dev, struct video_fontdata *fontdata
+ 		vc_priv->rows = vid_priv->ysize / fontdata->height;
+ 	}
+ 
++	if (priv->cursor_data)
++		free(priv->cursor_data);
++	priv->cursor_data = calloc(fontdata->height * VIDCONSOLE_CURSOR_WIDTH,
++				   sizeof(*priv->cursor_data));
++
+ 	return 0;
+ }
+ 
+@@ -75,6 +81,25 @@ inline void fill_pixel_and_goto_next(void **dstp, u32 value, int pbytes, int ste
+ 	*dstp = dst_byte + step;
+ }
+ 
++inline void copy_pixel_and_goto_next(void **srcp, u32 *value, int pbytes, int step)
++{
++	u8 *src_byte = *srcp;
++
++	if (pbytes == 4) {
++		u32 *src = *srcp;
++		*value = *src;
++	}
++	if (pbytes == 2) {
++		u16 *src = *srcp;
++		*value = *src;
++	}
++	if (pbytes == 1) {
++		u8 *src = *srcp;
++		*value = *src;
++	}
++	*srcp = src_byte + step;
++}
++
+ int fill_char_vertically(uchar *pfont, void **line, struct video_priv *vid_priv,
+ 			 struct video_fontdata *fontdata, bool direction)
+ {
+@@ -176,6 +201,76 @@ int fill_char_horizontally(uchar *pfont, void **line, struct video_priv *vid_pri
+ 	return ret;
+ }
+ 
++int cursor_save_fb(struct udevice *dev, void *line, struct video_priv *vid_priv,
++			   uint height, bool direction)
++{
++	struct console_simple_priv *priv = dev_get_priv(dev);
++	int step, line_step, pbytes, ret;
++	uint *value;
++	void *src;
++
++	if (!priv->cursor_data)
++		return 0;
++
++	ret = check_bpix_support(vid_priv->bpix);
++	if (ret)
++		return ret;
++
++	pbytes = VNBYTES(vid_priv->bpix);
++	if (direction) {
++		step = -pbytes;
++		line_step = -vid_priv->line_length;
++	} else {
++		step = pbytes;
++		line_step = vid_priv->line_length;
++	}
++
++	priv->cursor_line = line;
++	priv->cursor_stride = line_step;
++	priv->cursor_step = step;
++	priv->cursor_pbytes = pbytes;
++
++	for (int row = 0; row < height; row++) {
++		src = line;
++		for (int col = 0; col < VIDCONSOLE_CURSOR_WIDTH; col++) {
++			value = &priv->cursor_data[col + row * VIDCONSOLE_CURSOR_WIDTH];
++			copy_pixel_and_goto_next(&src, value, pbytes, step);
++		}
++		line += line_step;
++	}
++
++	priv->cursor_height = height;
++
++	return 0;
++}
++
++int cursor_restore_fb(struct udevice *dev)
++{
++	struct console_simple_priv *priv = dev_get_priv(dev);
++	void *line = priv->cursor_line;
++	int step = priv->cursor_step;
++	int line_step = priv->cursor_stride;
++	int pbytes = priv->cursor_pbytes;
++	uint value;
++
++	if (!priv->cursor_data || !priv->cursor_height || !line)
++		return 0;
++
++	for (int row = 0; row < priv->cursor_height; row++) {
++		void *dst = line;
++		for (int col = 0; col < VIDCONSOLE_CURSOR_WIDTH; col++) {
++			value = priv->cursor_data[col + row * VIDCONSOLE_CURSOR_WIDTH];
++			fill_pixel_and_goto_next(&dst, value, pbytes, step);
++		}
++		line += line_step;
++	}
++
++	priv->cursor_height = 0;
++	priv->cursor_line = NULL;
++
++	return 0;
++}
++
+ int draw_cursor_vertically(void **line, struct video_priv *vid_priv,
+ 			   uint height, bool direction)
+ {
+diff --git a/drivers/video/console_normal.c b/drivers/video/console_normal.c
+index a0231293f31..e3873fea389 100644
+--- a/drivers/video/console_normal.c
++++ b/drivers/video/console_normal.c
+@@ -119,6 +119,14 @@ static int console_set_cursor_visible(struct udevice *dev, bool visible,
+ 	x -= 1;
+ 
+ 	line = start;
++
++	cursor_restore_fb(dev);
++	if (!visible)
++		return 0;
++
++	cursor_save_fb(dev, line, vid_priv, vc_priv->y_charsize,
++		       NORMAL_DIRECTION);
++
+ 	draw_cursor_vertically(&line, vid_priv, vc_priv->y_charsize,
+ 			       NORMAL_DIRECTION);
+ 
+diff --git a/drivers/video/vidconsole_internal.h b/drivers/video/vidconsole_internal.h
+index 0ec581b2663..00b475aa729 100644
+--- a/drivers/video/vidconsole_internal.h
++++ b/drivers/video/vidconsole_internal.h
+@@ -16,6 +16,12 @@
+  */
+ struct console_simple_priv {
+ 	struct video_fontdata *fontdata;
++	u32 *cursor_data;
++	void *cursor_line;
++	int cursor_stride;
++	int cursor_step;
++	int cursor_pbytes;
++	u32 cursor_height;
+ };
+ 
+ /**
+@@ -92,6 +98,41 @@ int fill_char_vertically(uchar *pfont, void **line, struct video_priv *vid_priv,
+ int fill_char_horizontally(uchar *pfont, void **line, struct video_priv *vid_priv,
+ 			   struct video_fontdata *fontdata, bool direction);
+ 
++
++/**
++ * cursor_save_fb() - Save fb Draw a simple vertical cursor
++ *
++ * @param dev: a pointer to device.
++ * @line: pointer to framebuffer buffer: upper left cursor corner
++ * @vid_priv: driver private data
++ * @height: height of the cursor in pixels
++ * @param direction	controls cursor orientation. Can be normal or flipped.
++ * When normal:               When flipped:
++ *|-----------------------------------------------|
++ *|               *        |   line stepping      |
++ *|    ^  * * * * *        |   |                  |
++ *|    |    *     *        |   v   *     *        |
++ *|    |                   |       * * * * *      |
++ *|  line stepping         |       *              |
++ *|                        |                      |
++ *|  stepping ->           |        <<- stepping  |
++ *|---!!we're starting from upper left char corner|
++ *|-----------------------------------------------|
++ *
++ * Return: 0, if success, or else error code.
++ */
++int cursor_save_fb(struct udevice *dev, void *line, struct video_priv *vid_priv,
++		   uint height, bool direction);
++
++/**
++ * cursor_restore_fb() - Restore fb data under a previously rendered the cursor
++ *
++ * @param dev: a pointer to device.
++ *
++ * Return: 0, if success, or else error code.
++ */
++int cursor_restore_fb(struct udevice *dev);
++
+ /**
+  * draw_cursor_vertically() - Draw a simple vertical cursor
+  *

--- a/apple-silicon-support/packages/uboot-asahi/9e55d09596a5b6ec1f8cbfc3e97d29b9929dee86.patch
+++ b/apple-silicon-support/packages/uboot-asahi/9e55d09596a5b6ec1f8cbfc3e97d29b9929dee86.patch
@@ -1,0 +1,152 @@
+From 9e55d09596a5b6ec1f8cbfc3e97d29b9929dee86 Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Sun, 1 Oct 2023 19:13:18 -0600
+Subject: [PATCH] video: Allow obtaining the nominal size of a string size
+
+At present there is a method for measuring text, but if the actual text
+string is not known, it cannot be used.
+
+For text editor we want to set the size of the entry box to cover the
+expected text size. Add the concept of a 'norminal' size with a method
+to calculate that for the vidconsole.
+
+If the method is not implemented, fall back to using the font size,
+which is sufficient for fixed-width fonts.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c  | 31 +++++++++++++++++++++++++++++++
+ drivers/video/vidconsole-uclass.c | 22 ++++++++++++++++++++++
+ include/video_console.h           | 30 ++++++++++++++++++++++++++++++
+ 3 files changed, 83 insertions(+)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 0f9bb49e44f7..8ed79c37676c 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -750,6 +750,36 @@ int truetype_measure(struct udevice *dev, const char *name, uint size,
+ 	return 0;
+ }
+ 
++static int truetype_nominal(struct udevice *dev, const char *name, uint size,
++			    uint num_chars, struct vidconsole_bbox *bbox)
++{
++	struct console_tt_metrics *met;
++	stbtt_fontinfo *font;
++	int lsb, advance;
++	int width;
++	int ret;
++
++	ret = get_metrics(dev, name, size, &met);
++	if (ret)
++		return log_msg_ret("sel", ret);
++
++	font = &met->font;
++	width = 0;
++
++	/* First get some basic metrics about this character */
++	stbtt_GetCodepointHMetrics(font, 'W', &advance, &lsb);
++
++	width = advance;
++
++	bbox->valid = true;
++	bbox->x0 = 0;
++	bbox->y0 = 0;
++	bbox->x1 = tt_ceil((double)width * num_chars * met->scale);
++	bbox->y1 = met->font_size;
++
++	return 0;
++}
++
+ const char *console_truetype_get_font_size(struct udevice *dev, uint *sizep)
+ {
+ 	struct console_tt_priv *priv = dev_get_priv(dev);
+@@ -802,6 +832,7 @@ struct vidconsole_ops console_truetype_ops = {
+ 	.get_font_size	= console_truetype_get_font_size,
+ 	.select_font	= truetype_select_font,
+ 	.measure	= truetype_measure,
++	.nominal	= truetype_nominal,
+ };
+ 
+ U_BOOT_DRIVER(vidconsole_truetype) = {
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index b5b3b6625902..23b1b81731bc 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -618,6 +618,28 @@ int vidconsole_measure(struct udevice *dev, const char *name, uint size,
+ 	return 0;
+ }
+ 
++int vidconsole_nominal(struct udevice *dev, const char *name, uint size,
++		       uint num_chars, struct vidconsole_bbox *bbox)
++{
++	struct vidconsole_priv *priv = dev_get_uclass_priv(dev);
++	struct vidconsole_ops *ops = vidconsole_get_ops(dev);
++	int ret;
++
++	if (ops->measure) {
++		ret = ops->nominal(dev, name, size, num_chars, bbox);
++		if (ret != -ENOSYS)
++			return ret;
++	}
++
++	bbox->valid = true;
++	bbox->x0 = 0;
++	bbox->y0 = 0;
++	bbox->x1 = priv->x_charsize * num_chars;
++	bbox->y1 = priv->y_charsize;
++
++	return 0;
++}
++
+ void vidconsole_push_colour(struct udevice *dev, enum colour_idx fg,
+ 			    enum colour_idx bg, struct vidconsole_colour *old)
+ {
+diff --git a/include/video_console.h b/include/video_console.h
+index 2694e44f6ecf..5234c85efd6f 100644
+--- a/include/video_console.h
++++ b/include/video_console.h
+@@ -224,6 +224,21 @@ struct vidconsole_ops {
+ 	 */
+ 	int (*measure)(struct udevice *dev, const char *name, uint size,
+ 		       const char *text, struct vidconsole_bbox *bbox);
++
++	/**
++	 * nominal() - Measure the expected width of a line of text
++	 *
++	 * Uses an average font width and nominal height
++	 *
++	 * @dev: Console device to use
++	 * @name: Font name, NULL for default
++	 * @size: Font size, ignored if @name is NULL
++	 * @num_chars: Number of characters to use
++	 * @bbox: Returns nounding box of @num_chars characters
++	 * Returns: 0 if OK, -ve on error
++	 */
++	int (*nominal)(struct udevice *dev, const char *name, uint size,
++		       uint num_chars, struct vidconsole_bbox *bbox);
+ };
+ 
+ /* Get a pointer to the driver operations for a video console device */
+@@ -263,6 +278,21 @@ int vidconsole_select_font(struct udevice *dev, const char *name, uint size);
+ int vidconsole_measure(struct udevice *dev, const char *name, uint size,
+ 		       const char *text, struct vidconsole_bbox *bbox);
+ 
++/**
++ * vidconsole_nominal() - Measure the expected width of a line of text
++ *
++ * Uses an average font width and nominal height
++ *
++ * @dev: Console device to use
++ * @name: Font name, NULL for default
++ * @size: Font size, ignored if @name is NULL
++ * @num_chars: Number of characters to use
++ * @bbox: Returns nounding box of @num_chars characters
++ * Returns: 0 if OK, -ve on error
++ */
++int vidconsole_nominal(struct udevice *dev, const char *name, uint size,
++		       uint num_chars, struct vidconsole_bbox *bbox);
++
+ /**
+  * vidconsole_push_colour() - Temporarily change the font colour
+  *

--- a/apple-silicon-support/packages/uboot-asahi/a339b0112e45d6dbefcbf59d71928bd7702f46c6.patch
+++ b/apple-silicon-support/packages/uboot-asahi/a339b0112e45d6dbefcbf59d71928bd7702f46c6.patch
@@ -1,0 +1,109 @@
+From a339b0112e45d6dbefcbf59d71928bd7702f46c6 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Thu, 11 Jan 2024 19:21:20 +0100
+Subject: [PATCH] lib/charset: Map cp437 low chars (0x01 - 0x1f) from unicode
+
+Add mappings for code points 1 - 31 as those code points in code page 437
+are graphics.
+Thios fixes rendering issues of various EFI boot loaders (grub2,
+sd-boot, ...) using EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL.
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ include/charset.h |  2 +-
+ include/cp1250.h  | 12 ++++++++++--
+ include/cp437.h   | 12 ++++++++++--
+ lib/charset.c     |  9 ++++++---
+ 4 files changed, 27 insertions(+), 8 deletions(-)
+
+diff --git a/include/charset.h b/include/charset.h
+index 714382e1c19..c51c29235f6 100644
+--- a/include/charset.h
++++ b/include/charset.h
+@@ -16,7 +16,7 @@
+ /*
+  * codepage_437 - Unicode to codepage 437 translation table
+  */
+-extern const u16 codepage_437[128];
++extern const u16 codepage_437[160];
+ 
+ /**
+  * console_read_unicode() - read Unicode code point from console
+diff --git a/include/cp1250.h b/include/cp1250.h
+index adacf8a9580..b762c78d9f6 100644
+--- a/include/cp1250.h
++++ b/include/cp1250.h
+@@ -1,10 +1,18 @@
+ /* SPDX-License-Identifier: GPL-2.0+ */
+ 
+ /*
+- * Constant CP1250 contains the Unicode code points for characters 0x80 - 0xff
+- * of the code page 1250.
++ * Constant CP1250 contains the Unicode code points for characters 0x00 - 0x1f
++ * and 0x80 - 0xff of the code page 1250.
+  */
+ #define CP1250 { \
++	0x0000, 0x0000, 0x0000, 0x0000, \
++	0x0000, 0x0000, 0x0000, 0x0000, \
++	0x0000, 0x0000, 0x0000, 0x0000, \
++	0x0000, 0x0000, 0x0000, 0x0000, \
++	0x0000, 0x0000, 0x0000, 0x0000, \
++	0x0000, 0x0000, 0x0000, 0x0000, \
++	0x0000, 0x0000, 0x0000, 0x0000, \
++	0x0000, 0x0000, 0x0000, 0x0000, \
+ 	0x20ac, 0x0000, 0x201a, 0x0000, \
+ 	0x201e, 0x2026, 0x2020, 0x2021, \
+ 	0x0000, 0x2030, 0x0160, 0x2039, \
+diff --git a/include/cp437.h b/include/cp437.h
+index 0b2b97132e3..5093130f5ed 100644
+--- a/include/cp437.h
++++ b/include/cp437.h
+@@ -1,10 +1,18 @@
+ /* SPDX-License-Identifier: GPL-2.0+ */
+ 
+ /*
+- * Constant CP437 contains the Unicode code points for characters 0x80 - 0xff
+- * of the code page 437.
++ * Constant CP437 contains the Unicode code points for characters 0x00 - 0x1f
++ * and 0x80 - 0xff of the code page 437.
+  */
+ #define CP437 { \
++	0x0000, 0x263a, 0x263b, 0x2665, \
++	0x2666, 0x2663, 0x2660, 0x2022, \
++	0x25d8, 0x25cb, 0x25d9, 0x2642, \
++	0x2640, 0x266a, 0x266b, 0x263c, \
++	0x25ba, 0x25c4, 0x2195, 0x203c, \
++	0x00b6, 0x00a7, 0x25ac, 0x21a8, \
++	0x2191, 0x2193, 0x2192, 0x2190, \
++	0x221f, 0x2194, 0x25b2, 0x25bc, \
+ 	0x00c7, 0x00fc, 0x00e9, 0x00e2, \
+ 	0x00e4, 0x00e0, 0x00e5, 0x00e7, \
+ 	0x00ea, 0x00eb, 0x00e8, 0x00ef, \
+diff --git a/lib/charset.c b/lib/charset.c
+index 5e4c4f948a4..1f8480150ac 100644
+--- a/lib/charset.c
++++ b/lib/charset.c
+@@ -16,7 +16,7 @@
+ /**
+  * codepage_437 - Unicode to codepage 437 translation table
+  */
+-const u16 codepage_437[128] = CP437;
++const u16 codepage_437[160] = CP437;
+ 
+ static struct capitalization_table capitalization_table[] =
+ #ifdef CONFIG_EFI_UNICODE_CAPITALIZATION
+@@ -517,9 +517,12 @@ int utf_to_cp(s32 *c, const u16 *codepage)
+ 		int j;
+ 
+ 		/* Look up codepage translation */
+-		for (j = 0; j < 0x80; ++j) {
++		for (j = 0; j < 0xA0; ++j) {
+ 			if (*c == codepage[j]) {
+-				*c = j + 0x80;
++				if (j < 0x20)
++					*c = j;
++				else
++					*c = j + 0x60;
+ 				return 0;
+ 			}
+ 		}

--- a/apple-silicon-support/packages/uboot-asahi/a8f80409b06a39605aadaaf64bdbf71b31d463ca.patch
+++ b/apple-silicon-support/packages/uboot-asahi/a8f80409b06a39605aadaaf64bdbf71b31d463ca.patch
@@ -1,0 +1,65 @@
+From a8f80409b06a39605aadaaf64bdbf71b31d463ca Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Thu, 1 Jun 2023 10:22:36 -0600
+Subject: [PATCH] console: Correct truetype spacing error
+
+The putc_xy() method is supposed to return the amount of space used. The
+existing implementation erroneously adds the previous sub-pixel position
+to the returned value. This spaces out the characters very slightly more
+than it should. It is seldom noticeable but it does make accurate
+measurement of the text impossible.
+
+Fix this minor but long-standing bug.
+
+Fixes: a29b012037c ("video: Add a console driver that uses TrueType fonts")
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c | 2 +-
+ test/dm/video.c                  | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 63d7557c71a0..6f3fc82f9b05 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -256,7 +256,7 @@ static int console_truetype_putc_xy(struct udevice *dev, uint x, uint y,
+ 	 */
+ 	x_shift = xpos - (double)tt_floor(xpos);
+ 	xpos += advance * met->scale;
+-	width_frac = (int)VID_TO_POS(xpos);
++	width_frac = (int)VID_TO_POS(advance * met->scale);
+ 	if (x + width_frac >= vc_priv->xsize_frac)
+ 		return -EAGAIN;
+ 
+diff --git a/test/dm/video.c b/test/dm/video.c
+index 30778157d940..6d9c55c14035 100644
+--- a/test/dm/video.c
++++ b/test/dm/video.c
+@@ -556,7 +556,7 @@ static int dm_test_video_truetype(struct unit_test_state *uts)
+ 	ut_assertok(video_get_nologo(uts, &dev));
+ 	ut_assertok(uclass_get_device(UCLASS_VIDEO_CONSOLE, 0, &con));
+ 	vidconsole_put_string(con, test_string);
+-	ut_asserteq(12237, compress_frame_buffer(uts, dev));
++	ut_asserteq(12187, compress_frame_buffer(uts, dev));
+ 
+ 	return 0;
+ }
+@@ -577,7 +577,7 @@ static int dm_test_video_truetype_scroll(struct unit_test_state *uts)
+ 	ut_assertok(video_get_nologo(uts, &dev));
+ 	ut_assertok(uclass_get_device(UCLASS_VIDEO_CONSOLE, 0, &con));
+ 	vidconsole_put_string(con, test_string);
+-	ut_asserteq(35030, compress_frame_buffer(uts, dev));
++	ut_asserteq(34481, compress_frame_buffer(uts, dev));
+ 
+ 	return 0;
+ }
+@@ -598,7 +598,7 @@ static int dm_test_video_truetype_bs(struct unit_test_state *uts)
+ 	ut_assertok(video_get_nologo(uts, &dev));
+ 	ut_assertok(uclass_get_device(UCLASS_VIDEO_CONSOLE, 0, &con));
+ 	vidconsole_put_string(con, test_string);
+-	ut_asserteq(29018, compress_frame_buffer(uts, dev));
++	ut_asserteq(29579, compress_frame_buffer(uts, dev));
+ 
+ 	return 0;
+ }

--- a/apple-silicon-support/packages/uboot-asahi/b828ed7d79295cfebcb0f958f26a33664fae045c.patch
+++ b/apple-silicon-support/packages/uboot-asahi/b828ed7d79295cfebcb0f958f26a33664fae045c.patch
@@ -1,0 +1,219 @@
+From b828ed7d79295cfebcb0f958f26a33664fae045c Mon Sep 17 00:00:00 2001
+From: Simon Glass <sjg@chromium.org>
+Date: Thu, 1 Jun 2023 10:22:46 -0600
+Subject: [PATCH] console: Allow measuring the bounding box of text
+
+For laying out text accurately it is necessary to know the width and
+height of the text. Add a measure() method to the console API, so this
+can be supported.
+
+Add an implementation for truetype and a base implementation for the
+normal console.
+
+Signed-off-by: Simon Glass <sjg@chromium.org>
+---
+ drivers/video/console_truetype.c  | 64 ++++++++++++++++++++++++++++++-
+ drivers/video/vidconsole-uclass.c | 22 +++++++++++
+ include/video_console.h           | 48 +++++++++++++++++++++++
+ 3 files changed, 132 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/video/console_truetype.c b/drivers/video/console_truetype.c
+index 6f3fc82f9b05..288123a2e065 100644
+--- a/drivers/video/console_truetype.c
++++ b/drivers/video/console_truetype.c
+@@ -614,8 +614,8 @@ static void select_metrics(struct udevice *dev, struct console_tt_metrics *met)
+ 	vc_priv->tab_width_frac = VID_TO_POS(met->font_size) * 8 / 2;
+ }
+ 
+-static int truetype_select_font(struct udevice *dev, const char *name,
+-				uint size)
++static int get_metrics(struct udevice *dev, const char *name, uint size,
++		       struct console_tt_metrics **metp)
+ {
+ 	struct console_tt_priv *priv = dev_get_priv(dev);
+ 	struct console_tt_metrics *met;
+@@ -653,11 +653,70 @@ static int truetype_select_font(struct udevice *dev, const char *name,
+ 		met = priv->metrics;
+ 	}
+ 
++	*metp = met;
++
++	return 0;
++}
++
++static int truetype_select_font(struct udevice *dev, const char *name,
++				uint size)
++{
++	struct console_tt_metrics *met;
++	int ret;
++
++	ret = get_metrics(dev, name, size, &met);
++	if (ret)
++		return log_msg_ret("sel", ret);
++
+ 	select_metrics(dev, met);
+ 
+ 	return 0;
+ }
+ 
++int truetype_measure(struct udevice *dev, const char *name, uint size,
++		     const char *text, struct vidconsole_bbox *bbox)
++{
++	struct console_tt_metrics *met;
++	stbtt_fontinfo *font;
++	int lsb, advance;
++	const char *s;
++	int width;
++	int last;
++	int ret;
++
++	ret = get_metrics(dev, name, size, &met);
++	if (ret)
++		return log_msg_ret("sel", ret);
++
++	bbox->valid = false;
++	if (!*text)
++		return 0;
++
++	font = &met->font;
++	width = 0;
++	for (last = 0, s = text; *s; s++) {
++		int ch = *s;
++
++		/* Used kerning to fine-tune the position of this character */
++		if (last)
++			width += stbtt_GetCodepointKernAdvance(font, last, ch);
++
++		/* First get some basic metrics about this character */
++		stbtt_GetCodepointHMetrics(font, ch, &advance, &lsb);
++
++		width += advance;
++		last = ch;
++	}
++
++	bbox->valid = true;
++	bbox->x0 = 0;
++	bbox->y0 = 0;
++	bbox->x1 = tt_ceil((double)width * met->scale);
++	bbox->y1 = met->font_size;
++
++	return 0;
++}
++
+ const char *console_truetype_get_font_size(struct udevice *dev, uint *sizep)
+ {
+ 	struct console_tt_priv *priv = dev_get_priv(dev);
+@@ -709,6 +768,7 @@ struct vidconsole_ops console_truetype_ops = {
+ 	.get_font	= console_truetype_get_font,
+ 	.get_font_size	= console_truetype_get_font_size,
+ 	.select_font	= truetype_select_font,
++	.measure	= truetype_measure,
+ };
+ 
+ U_BOOT_DRIVER(vidconsole_truetype) = {
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index 3f89537c47b7..05f930478096 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -596,6 +596,28 @@ int vidconsole_select_font(struct udevice *dev, const char *name, uint size)
+ 	return ops->select_font(dev, name, size);
+ }
+ 
++int vidconsole_measure(struct udevice *dev, const char *name, uint size,
++		       const char *text, struct vidconsole_bbox *bbox)
++{
++	struct vidconsole_priv *priv = dev_get_uclass_priv(dev);
++	struct vidconsole_ops *ops = vidconsole_get_ops(dev);
++	int ret;
++
++	if (ops->select_font) {
++		ret = ops->measure(dev, name, size, text, bbox);
++		if (ret != -ENOSYS)
++			return ret;
++	}
++
++	bbox->valid = true;
++	bbox->x0 = 0;
++	bbox->y0 = 0;
++	bbox->x1 = priv->x_charsize * strlen(text);
++	bbox->y1 = priv->y_charsize;
++
++	return 0;
++}
++
+ void vidconsole_push_colour(struct udevice *dev, enum colour_idx fg,
+ 			    enum colour_idx bg, struct vidconsole_colour *old)
+ {
+diff --git a/include/video_console.h b/include/video_console.h
+index 81d4c4d874df..2694e44f6ecf 100644
+--- a/include/video_console.h
++++ b/include/video_console.h
+@@ -82,6 +82,27 @@ struct vidconsole_colour {
+ 	u32 colour_bg;
+ };
+ 
++/**
++ * struct vidconsole_bbox - Bounding box of text
++ *
++ * This describes the bounding box of something, measured in pixels. The x0/y0
++ * pair is inclusive; the x1/y2 pair is exclusive, meaning that it is one pixel
++ * beyond the extent of the object
++ *
++ * @valid: Values are valid (bounding box is known)
++ * @x0: left x position, in pixels from left side
++ * @y0: top y position, in pixels from top
++ * @x1: right x position + 1
++ * @y1: botton y position + 1
++ */
++struct vidconsole_bbox {
++	bool valid;
++	int x0;
++	int y0;
++	int x1;
++	int y1;
++};
++
+ /**
+  * struct vidconsole_ops - Video console operations
+  *
+@@ -189,6 +210,20 @@ struct vidconsole_ops {
+ 	 * Returns: 0 on success, -ENOENT if no such font
+ 	 */
+ 	int (*select_font)(struct udevice *dev, const char *name, uint size);
++
++	/**
++	 * measure() - Measure the bounds of some text
++	 *
++	 * @dev:	Device to adjust
++	 * @name:	Font name to use (NULL to use default)
++	 * @size:	Font size to use (0 to use default)
++	 * @text:	Text to measure
++	 * @bbox:	Returns bounding box of text, assuming it is positioned
++	 *		at 0,0
++	 * Returns: 0 on success, -ENOENT if no such font
++	 */
++	int (*measure)(struct udevice *dev, const char *name, uint size,
++		       const char *text, struct vidconsole_bbox *bbox);
+ };
+ 
+ /* Get a pointer to the driver operations for a video console device */
+@@ -215,6 +250,19 @@ int vidconsole_get_font(struct udevice *dev, int seq,
+  */
+ int vidconsole_select_font(struct udevice *dev, const char *name, uint size);
+ 
++/*
++ * vidconsole_measure() - Measuring the bounding box of some text
++ *
++ * @dev: Console device to use
++ * @name: Font name, NULL for default
++ * @size: Font size, ignored if @name is NULL
++ * @text: Text to measure
++ * @bbox: Returns nounding box of text
++ * Returns: 0 if OK, -ve on error
++ */
++int vidconsole_measure(struct udevice *dev, const char *name, uint size,
++		       const char *text, struct vidconsole_bbox *bbox);
++
+ /**
+  * vidconsole_push_colour() - Temporarily change the font colour
+  *

--- a/apple-silicon-support/packages/uboot-asahi/ccca7c676023de6607f9ce91204b076045c8b6d1.patch
+++ b/apple-silicon-support/packages/uboot-asahi/ccca7c676023de6607f9ce91204b076045c8b6d1.patch
@@ -1,0 +1,27 @@
+From ccca7c676023de6607f9ce91204b076045c8b6d1 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Thu, 11 Jan 2024 20:28:59 +0100
+Subject: [PATCH] lib: charset: Fix utf8_to_utf32_stream() return value doc
+ string
+
+The comment appears to be copied from utf8_to_cp437_stream() but was not
+updated.
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ include/charset.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/charset.h b/include/charset.h
+index 44034c71d3d..714382e1c19 100644
+--- a/include/charset.h
++++ b/include/charset.h
+@@ -328,7 +328,7 @@ int utf8_to_cp437_stream(u8 c, char *buffer);
+  *
+  * @c:		next UTF-8 character to convert
+  * @buffer:	buffer, at least 5 characters
+- * Return:	next codepage 437 character or 0
++ * Return:	next Unicode code point or 0
+  */
+ int utf8_to_utf32_stream(u8 c, char *buffer);
+ 

--- a/apple-silicon-support/packages/uboot-asahi/default.nix
+++ b/apple-silicon-support/packages/uboot-asahi/default.nix
@@ -22,6 +22,9 @@
   ];
   extraConfig = ''
     CONFIG_IDENT_STRING=" ${version}"
+    CONFIG_CMD_NFS=n
+    CONFIG_VIDEO_LOGO=n
+    CONFIG_BOOTDELAY=2
     CONFIG_VIDEO_FONT_4X6=n
     CONFIG_VIDEO_FONT_8X16=n
     CONFIG_VIDEO_FONT_SUN12X22=n
@@ -29,7 +32,39 @@
   '';
 }).overrideAttrs (o: {
   # nixos's downstream patches are not applicable
-  patches = [ 
+  patches = [
+    # fix Mac Studios with 8TB NVME SSDs
+    ./8c9b59982d60847f7514d3367aa8cd0f9e178727.patch
+    # cherry-pick fixes from upstream u-boot
+    # so that Janne's patches apply cleanly
+    ./7a2fee8d29a92eadac3fc656d2686ccd20c24a08.patch
+    ./7432f68c53526980d0a2b2ffd54fe61141bb1178.patch
+    ./0ab4f91a107832692781a367a1ef2173af75f108.patch
+    ./a8f80409b06a39605aadaaf64bdbf71b31d463ca.patch
+    ./648a4991d0713af656a2fa50ec8e708c2beb044e.patch
+    ./b828ed7d79295cfebcb0f958f26a33664fae045c.patch
+    ./04f3dcd503a537fab50329686874559dae8a1a22.patch
+    ./01c76f1a64ba8cb3da9b26be481e289ee16960f0.patch
+    ./9e55d09596a5b6ec1f8cbfc3e97d29b9929dee86.patch
+    ./9899eef2cb41a9cde1dca87f3ddb041e347b177a.patch
+    ./37db20d0a64132a7ae3d0223de6b93167d60bea4.patch
+    ./617d7b545b6fa555f47944a10b1a1b261491e3b9.patch
+    ./6d225ec0cc5251c540164b4303261d29f0ade644.patch
+    ./7c00b80d48cbb28e5f6dfc232c344526e28f7176.patch
+    # Janne Grunau's patches to fix the EFI console:
+    # with these patches, the NixOS configuration boot
+    # picker renders correctly, without all of the
+    # goofy characters at the bottom
+    ./6524e8095eeefda61c1daca2ffb19224dd65618f.patch
+    ./ccca7c676023de6607f9ce91204b076045c8b6d1.patch
+    ./f27a89f6afa226a92f5e241f5c4fef98f872b4af.patch
+    ./a339b0112e45d6dbefcbf59d71928bd7702f46c6.patch
+    ./826c4e38d45bf45f214f8bde6928ffb78bb42c66.patch
+    ./9661d323264927941b1cd858b4bab349ee024c50.patch
+    ./9b425d0b06881e377bef99b3192dba24dcd97e5a.patch
+    ./e1c1bf91dc8b4f6c8aad61735c43e0cbdb448773.patch
+    ./f9d39fa1479550fb766a7720a7ca933ad2854cf7.patch
+    ./477c92689a374f13e5792a0216509b6696798c29.patch
   ];
 
   # flag somehow breaks DTC compilation so we remove it

--- a/apple-silicon-support/packages/uboot-asahi/e1c1bf91dc8b4f6c8aad61735c43e0cbdb448773.patch
+++ b/apple-silicon-support/packages/uboot-asahi/e1c1bf91dc8b4f6c8aad61735c43e0cbdb448773.patch
@@ -1,0 +1,20 @@
+From e1c1bf91dc8b4f6c8aad61735c43e0cbdb448773 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Sat, 13 Jan 2024 18:48:34 +0100
+Subject: [PATCH] video: console: Enable cursor
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ drivers/video/vidconsole-uclass.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index e36f823d74..47443d30d1 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -796,4 +796,5 @@ void vidconsole_position_cursor(struct udevice *dev, unsigned col, unsigned row)
+ 	x = min_t(short, col * priv->x_charsize, vid_priv->xsize - 1);
+ 	y = min_t(short, row * priv->y_charsize, vid_priv->ysize - 1);
+ 	vidconsole_set_cursor_pos(dev, x, y);
++	vidconsole_set_cursor_visible(dev, true, x, y, 0);
+ }

--- a/apple-silicon-support/packages/uboot-asahi/f27a89f6afa226a92f5e241f5c4fef98f872b4af.patch
+++ b/apple-silicon-support/packages/uboot-asahi/f27a89f6afa226a92f5e241f5c4fef98f872b4af.patch
@@ -1,0 +1,69 @@
+From f27a89f6afa226a92f5e241f5c4fef98f872b4af Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Wed, 10 Jan 2024 23:18:52 +0100
+Subject: [PATCH] video: Convert UTF-8 input stream to the 437 code page
+
+The bitmap fonts (VGA 8x16 and friends) we import from Linux use the
+437 code page to map their glyphs. For U-Boot's own purposes this is
+probably fine, but UEFI applications output Unicode, which only matches
+in the very basic first 127 characters.
+
+Use utf8_to_cp437_stream() to convert UTF-8 character sequences into the
+respective CP437 code point, as far as the characters defined in there
+allow this. This includes quite some international and box drawing
+characters, which are used by UEFI applications.
+
+Link: https://lore.kernel.org/u-boot/20220110005638.21599-9-andre.przywara@arm.com/
+Based-on-work-by: Andre Przywara <andre.przywara@arm.com>
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ drivers/video/vidconsole-uclass.c | 6 ++++++
+ include/video_console.h           | 4 ++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/drivers/video/vidconsole-uclass.c b/drivers/video/vidconsole-uclass.c
+index 22d55df71f6..577ca5f66e2 100644
+--- a/drivers/video/vidconsole-uclass.c
++++ b/drivers/video/vidconsole-uclass.c
+@@ -11,6 +11,7 @@
+ 
+ #include <common.h>
+ #include <abuf.h>
++#include <charset.h>
+ #include <command.h>
+ #include <console.h>
+ #include <log.h>
+@@ -489,6 +490,11 @@ int vidconsole_put_char(struct udevice *dev, char ch)
+ 		priv->last_ch = 0;
+ 		break;
+ 	default:
++#ifdef CONFIG_EFI_LOADER
++		ch = utf8_to_cp437_stream(ch, priv->utf8_cp437_buf);
++		if (ch == 0)
++			return 0;
++#endif
+ 		ret = vidconsole_output_glyph(dev, ch);
+ 		if (ret < 0)
+ 			return ret;
+diff --git a/include/video_console.h b/include/video_console.h
+index bde67fa9a5a..cea42e75581 100644
+--- a/include/video_console.h
++++ b/include/video_console.h
+@@ -43,6 +43,7 @@ enum {
+  * @col_saved:		Saved X position, in fractional units (VID_TO_POS(x))
+  * @row_saved:		Saved Y position in pixels (0=top)
+  * @escape_buf:		Buffer to accumulate escape sequence
++ * @utf8_cp437_buf:	Buffer to accumulate UTF-8 byte sequence
+  */
+ struct vidconsole_priv {
+ 	struct stdio_dev sdev;
+@@ -66,6 +67,9 @@ struct vidconsole_priv {
+ 	int row_saved;
+ 	int col_saved;
+ 	char escape_buf[32];
++#ifdef CONFIG_EFI_LOADER
++	char utf8_cp437_buf[8];
++#endif
+ };
+ 
+ /**

--- a/apple-silicon-support/packages/uboot-asahi/f9d39fa1479550fb766a7720a7ca933ad2854cf7.patch
+++ b/apple-silicon-support/packages/uboot-asahi/f9d39fa1479550fb766a7720a7ca933ad2854cf7.patch
@@ -1,0 +1,30 @@
+From f9d39fa1479550fb766a7720a7ca933ad2854cf7 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Thu, 11 Jan 2024 00:50:43 +0100
+Subject: [PATCH] video: console: Select default font based on
+ video_priv.font_size
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ drivers/video/console_core.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/video/console_core.c b/drivers/video/console_core.c
+index f137333f73..acd526830c 100644
+--- a/drivers/video/console_core.c
++++ b/drivers/video/console_core.c
+@@ -304,6 +304,14 @@ int draw_cursor_vertically(void **line, struct video_priv *vid_priv,
+ 
+ int console_probe(struct udevice *dev)
+ {
++	struct video_fontdata *font;
++	struct video_priv *vid_priv = dev_get_uclass_priv(dev->parent);
++
++	for (font = fonts; font->name; font++) {
++		if (font->height == vid_priv->font_size)
++			return console_set_font(dev, font);
++	}
++
+ 	return console_set_font(dev, fonts);
+ }
+ 


### PR DESCRIPTION
* fix Mac Studios with 8TB internal SSDs.  patch comes from:

https://github.com/jannau/u-boot-1/commits/apple-rtkit-boot-timeout/

* apply Janne Grunau's patch series that fixes font rendering and adds proper cursor support to the EFI console.  These fixes are sufficient to finally fix the NixOS generation boot picker, so that the text renders correctly with no garbage characters at the bottom. In addition, the 5-second timer is now visible. Patch series taken from:

https://github.com/jannau/u-boot-1/commits/asahi-vidconsole-fixes/

* Janne's patch series for font rendering was written against upstream u-boot 2024.01, not the Asahi u-boot branch.  Thus we cherry-pick commits from upstream so that Janne's patches apply cleanly.
* forcefully disable CMD_NFS to achieve the same security improvement as this Fedora Asahi Remix patch:

https://copr-dist-git.fedorainfracloud.org/cgit/@asahi/u-boot/uboot-tools.git/tree/0001-disable-NFS-support-by-default.patch?h=f39

* decrease the boot delay to speed up overall boot time
* disable the submarine logo on boot because it looks goofy

These fixes have all been boot-tested successfully on my MacBook Air M1.