### PR TITLE
kernel: disable IO scheduler on Apple NVME

### DIFF
--- a/apple-silicon-support/modules/kernel/default.nix
+++ b/apple-silicon-support/modules/kernel/default.nix
@@ -17,6 +17,16 @@
     # source: https://www.kernel.org/doc/html/latest/scheduler/sched-energy.html
     powerManagement.cpuFreqGovernor = lib.mkOverride 800 "schedutil";
 
+    # using an IO scheduler is pretty pointless on NVME devices as fast as Apple's
+    # disable the IO scheduler on NVME to conserve CPU cycles
+    # sources:
+    # https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers
+    # https://www.phoronix.com/review/linux-56-nvme/4
+    services.udev.extraRules = ''
+      ACTION=="add|change", KERNEL=="nvme[0-9]*n[0-9]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="none"
+    '';
+
+
     boot.initrd.includeDefaultModules = false;
     boot.initrd.availableKernelModules = [
       # list of initrd modules stolen from


### PR DESCRIPTION
By default the internal NVME SSD gets the "mq-deadline" IO scheduler applied to it.

According to Ubuntu's documentation, choosing "none" as the IO scheduler provides "minimal overhead" and is "Ideal for fast random I/O devices such as NVME".

https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers

According to benchmarks compiled by Phoronix, "overall though, using 'none' as your I/O scheduler option will still generally offer the best performance for speedy NVMe SSD storage with a few exceptions".

https://www.phoronix.com/review/linux-56-nvme/4

This commit changes the IO scheduler for NVME devices from mq-deadline to none.  Successfully tested on my MacBook Air M1.