### PR TITLE
Update kernel and mesa to support OpenGL 4.6

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -96,8 +96,8 @@ let
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.6-14";
-        hash = "sha256-+ydX2XXIbcVfq27WC68EPP8n3bf+WD5fDG7FBq3QJi4=";
+        rev = "asahi-6.6-15";
+        hash = "sha256-Jm7wTKWuwd/6ZN0g5F4CNNETiOyGQL31hfSyTDYH85k=";
       };
 
       kernelPatches = [

--- a/apple-silicon-support/packages/mesa-asahi-edge/default.nix
+++ b/apple-silicon-support/packages/mesa-asahi-edge/default.nix
@@ -13,14 +13,14 @@
 }).overrideAttrs (oldAttrs: {
   # version must be the same length (i.e. no unstable or date)
   # so that system.replaceRuntimeDependencies can work
-  version = "24.0.0";
+  version = "24.1.0";
   src = fetchFromGitLab {
     # tracking: https://pagure.io/fedora-asahi/mesa/commits/asahi
     domain = "gitlab.freedesktop.org";
     owner = "asahi";
     repo = "mesa";
-    rev = "asahi-20231213";
-    hash = "sha256-hl0JtwWEXaCkhCMQJ393mzfw/eEx6m9DYNS+spQ3Vhs=";
+    rev = "asahi-20240218";
+    hash = "sha256-IMR6x7xYUOp/IBycL8RKs4lbInEh2Xfu6Kjom4S+D/s=";
   };
 
   mesonFlags =


### PR DESCRIPTION
For more information, see [Conformant OpenGL 4.6 on the M1](https://rosenzweig.io/blog/conformant-gl46-on-the-m1.html). This updates to the latest asahi-linux kernel tag as well as the latest mesa-asahi-edge tag.

Works on my machine™ (m1 pro).

This allows blender and other tools to run.
