### PR TITLE
asahi-nvram: add asahi-nvram 0.2.1

### DIFF
--- a/apple-silicon-support/packages/asahi-nvram/default.nix
+++ b/apple-silicon-support/packages/asahi-nvram/default.nix
@@ -1,0 +1,16 @@
+{ fetchCrate
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "asahi-nvram";
+  version = "0.2.1";
+
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-bFUFjHVTYj0eUmhijraOdeCvAt2UGX8+yyvooYN1Uo0=";
+  };
+
+  cargoHash = "sha256-WhySIQew8xxdwXLWkpvTYQZFiqCEPjEAjr7NVxfjDkU=";
+  cargoDepsName = pname;
+}

--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -8,4 +8,5 @@ final: prev: {
   speakersafetyd = final.callPackage ./speakersafetyd { };
   bankstown-lv2 = final.callPackage ./bankstown-lv2 { };
   asahi-audio = final.callPackage ./asahi-audio { };
+  asahi-nvram = final.callPackage ./asahi-nvram { };
 }


### PR DESCRIPTION
This PR adds the asahi-nvram tool. The other tools ([asahi-bless](https://github.com/WhatAmISupposedToPutHere/asahi-nvram/tree/master/asahi-bless), [asahi-btsync](https://github.com/WhatAmISupposedToPutHere/asahi-nvram/tree/master/asahi-btsync), [asahi-wifisync](https://github.com/WhatAmISupposedToPutHere/asahi-nvram/tree/master/asahi-wifisync)) should be similar.