### PR TITLE
modules/sound: select `asahi-audio` version conditionally

### DIFF
--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -60,6 +60,9 @@
       systemd.user.services.pipewire.environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
       systemd.user.services.wireplumber.environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
 
+      # wireplumber 0.5 looks for scripts in datadirs only
+      systemd.user.services.wireplumber.environment.XDG_DATA_DIRS = "${asahi-audio}/share";
+
       # enable speakersafetyd to protect speakers
       systemd.packages = lib.mkAssert lsp-plugins-is-safe
         "lsp-plugins is unpatched/outdated and speakers cannot be safely enabled"

--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -69,11 +69,23 @@
         [ pkgs.speakersafetyd ];
       services.udev.packages = [ pkgs.speakersafetyd ];
 
-      # select appropriate asahi-audio version using wireplumber
+      # select appropriate asahi-audio/wireplumber versions using nixpkgs wireplumber version
       nixpkgs.overlays = [(final: prev: {
         asahi-audio = if (lib.versionAtLeast prev.wireplumber.version "0.5.2")
-                      then prev.asahi-audio-2_x
-                      else prev.asahi-audio-1_x;
+	  then prev.asahi-audio-2_x
+	  else prev.asahi-audio-1_x;
+
+        wireplumber = prev.wireplumber.overrideAttrs (old:
+          lib.optionalAttrs (!lib.versionAtLeast old.version "0.5.2") rec {
+            version = "0.4.17";
+            src = final.fetchFromGitLab {
+              domain = "gitlab.freedesktop.org";
+              owner = "pipewire";
+              repo = "wireplumber";
+              rev = version;
+              hash = "sha256-vhpQT67+849WV1SFthQdUeFnYe/okudTQJoL3y+wXwI=";
+            };
+          });
       })];
     }
     (lib.optionalAttrs newHotness {

--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -71,7 +71,7 @@
 
       # select appropriate asahi-audio version using wireplumber
       nixpkgs.overlays = [(final: prev: {
-        asahi-audio = if (lib.versionAtLeast prev.wireplumber.version "0.5.0")
+        asahi-audio = if (lib.versionAtLeast prev.wireplumber.version "0.5.2")
                       then prev.asahi-audio-2_x
                       else prev.asahi-audio-1_x;
       })];

--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -66,19 +66,11 @@
         [ pkgs.speakersafetyd ];
       services.udev.packages = [ pkgs.speakersafetyd ];
 
-      # downgrade wireplumber to a version compatible with the asahi-audio configs
+      # select appropriate asahi-audio version using wireplumber
       nixpkgs.overlays = [(final: prev: {
-        wireplumber = prev.wireplumber.overrideAttrs (old:
-          lib.optionalAttrs (lib.versionAtLeast old.version "0.5.0") rec {
-            version = "0.4.17";
-            src = final.fetchFromGitLab {
-              domain = "gitlab.freedesktop.org";
-              owner = "pipewire";
-              repo = "wireplumber";
-              rev = version;
-              hash = "sha256-vhpQT67+849WV1SFthQdUeFnYe/okudTQJoL3y+wXwI=";
-            };
-          });
+        asahi-audio = if (lib.versionAtLeast prev.wireplumber.version "0.5.0")
+                      then prev.asahi-audio-2_x
+                      else prev.asahi-audio-1_x;
       })];
     }
     (lib.optionalAttrs newHotness {

--- a/apple-silicon-support/packages/asahi-audio/common.nix
+++ b/apple-silicon-support/packages/asahi-audio/common.nix
@@ -1,20 +1,15 @@
+{ version
+, src
+, providedConfigFiles
+}:
+
 { stdenv
 , lib
-, fetchFromGitHub
 }:
 
 stdenv.mkDerivation rec {
   pname = "asahi-audio";
-  # tracking: https://src.fedoraproject.org/rpms/asahi-audio
-  # note: ensure that the providedConfigFiles list below is current!
-  version = "1.6";
-
-  src = fetchFromGitHub {
-    owner = "AsahiLinux";
-    repo = "asahi-audio";
-    rev = "v${version}";
-    hash = "sha256-NxTQD742U2FUZNmw7RHuOruMuTRLtAh1HDlMV9EzQkg=";
-  };
+  inherit version src;
 
   preBuild = ''
     export PREFIX=$out
@@ -40,12 +35,5 @@ stdenv.mkDerivation rec {
   # /etc/, from the `install -pm0644 conf/` lines in the Makefile. note
   # that the contents of asahi-audio/ stay in $out/ and the config files
   # are modified to point to them.
-  passthru.providedConfigFiles = [
-    "wireplumber/wireplumber.conf.d/99-asahi.conf"
-    "wireplumber/policy.lua.d/85-asahi-policy.lua"
-    "wireplumber/main.lua.d/85-asahi.lua"
-    "wireplumber/scripts/policy-asahi.lua"
-    "pipewire/pipewire.conf.d/99-asahi.conf"
-    "pipewire/pipewire-pulse.conf.d/99-asahi.conf"
-  ];
+  passthru = { inherit providedConfigFiles; };
 }

--- a/apple-silicon-support/packages/asahi-audio/packages.nix
+++ b/apple-silicon-support/packages/asahi-audio/packages.nix
@@ -31,9 +31,9 @@ in {
   };
 
   asahi-audio-2_x = callPackage' {
-    version = "2.0+git20240401";
-    rev = "6428f52c56c71a28cf3bf641cd559de17d610830";
-    hash = "sha256-OUDwdCcRrWRWOMhDCaEZ7Naw4m02O18MXgfDaRXU2sc=";
+    version = "2.0+git20240418";
+    rev = "29ec1056c18193ffa09a990b1b61ed273e97fee6";
+    hash = "sha256-OwzO1x3rUajB/XMUnBGhTKKD9D36izFmCRd7JALumHc=";
 
     providedConfigFiles = [
       "wireplumber/wireplumber.conf.d/99-asahi.conf"

--- a/apple-silicon-support/packages/asahi-audio/packages.nix
+++ b/apple-silicon-support/packages/asahi-audio/packages.nix
@@ -1,0 +1,45 @@
+{ lib, callPackage, fetchFromGitHub }:
+
+let
+  # tracking: https://src.fedoraproject.org/rpms/asahi-audio
+  # note: ensure that the providedConfigFiles list below is current!
+  owner = "AsahiLinux";
+  repo = "asahi-audio";
+
+  callPackage' = args: callPackage (import ./common.nix {
+    inherit (args) version providedConfigFiles;
+
+    src = fetchFromGitHub rec {
+      inherit owner repo;
+      inherit (args) rev hash;
+    };
+  }) { };
+in {
+  asahi-audio-1_x = callPackage' rec {
+    version = "1.8";
+    rev = "v${version}";
+    hash = "sha256-+3nmBJbyxw+8PZ3di1YVImU6tNPK4q5xC70WQK7jnOk=";
+
+    providedConfigFiles = [
+      "wireplumber/wireplumber.conf.d/99-asahi.conf"
+      "wireplumber/policy.lua.d/85-asahi-policy.lua"
+      "wireplumber/main.lua.d/85-asahi.lua"
+      "wireplumber/scripts/policy-asahi.lua"
+      "pipewire/pipewire.conf.d/99-asahi.conf"
+      "pipewire/pipewire-pulse.conf.d/99-asahi.conf"
+    ];
+  };
+
+  asahi-audio-2_x = callPackage' {
+    version = "2.0+git20240401";
+    rev = "6428f52c56c71a28cf3bf641cd559de17d610830";
+    hash = "sha256-OUDwdCcRrWRWOMhDCaEZ7Naw4m02O18MXgfDaRXU2sc=";
+
+    providedConfigFiles = [
+      "wireplumber/wireplumber.conf.d/99-asahi.conf"
+      "wireplumber/scripts/device/asahi-limit-volume.lua"
+      "pipewire/pipewire.conf.d/99-asahi.conf"
+      "pipewire/pipewire-pulse.conf.d/99-asahi.conf"
+    ];
+  };
+}

--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -7,5 +7,4 @@ final: prev: {
   alsa-ucm-conf-asahi = final.callPackage ./alsa-ucm-conf-asahi { inherit (prev) alsa-ucm-conf; };
   speakersafetyd = final.callPackage ./speakersafetyd { };
   bankstown-lv2 = final.callPackage ./bankstown-lv2 { };
-  asahi-audio = final.callPackage ./asahi-audio { };
-}
+} // (import ./asahi-audio/packages.nix { inherit (final) lib callPackage fetchFromGitHub; })


### PR DESCRIPTION
`asahi-audio` is committing to support of a `compat/1.x` branch for Wireplumber versions below `0.5` until near the end of 2024: https://github.com/AsahiLinux/asahi-audio/commit/04e905abdb5f561126fcd29be809d5b3ff95b820

This PR splits the `asahi-audio` package into `1_x` and `2_x` variants, allowing us to select a version conditionally based on the Wireplumber version in `nixpkgs`. This allows users to continue tracking whatever version of `nixpkgs` independent from the Wireplumber version.