### PR TITLE
modules/sound: upgrade asahi-audio to 2.2

### DIFF
--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -66,20 +66,14 @@
         [ pkgs.speakersafetyd ];
       services.udev.packages = [ pkgs.speakersafetyd ];
 
-      # downgrade wireplumber to a version compatible with the asahi-audio configs
-      nixpkgs.overlays = [(final: prev: {
-        wireplumber = prev.wireplumber.overrideAttrs (old:
-          lib.optionalAttrs (lib.versionAtLeast old.version "0.5.0") rec {
-            version = "0.4.17";
-            src = final.fetchFromGitLab {
-              domain = "gitlab.freedesktop.org";
-              owner = "pipewire";
-              repo = "wireplumber";
-              rev = version;
-              hash = "sha256-vhpQT67+849WV1SFthQdUeFnYe/okudTQJoL3y+wXwI=";
-            };
-          });
-      })];
+      # assert wireplumber 0.5.2 and above
+      # https://github.com/AsahiLinux/asahi-audio/commit/29ec1056c18193ffa09a990b1b61ed273e97fee6
+      assertions = [
+        {
+          assertion = lib.versionAtLeast pkgs.wireplumber.version "0.5.2";
+          message = "wireplumber >= 0.5.2 is required for nixos-apple-silicon.";
+        }
+      ];
     }
     (lib.optionalAttrs newHotness {
       # use configPackages and friends to install asahi-audio and plugins
@@ -100,6 +94,7 @@
 
       systemd.user.services.pipewire.environment.LV2_PATH = lv2Path;
       systemd.user.services.wireplumber.environment.LV2_PATH = lv2Path;
+      systemd.user.services.wireplumber.environment.XDG_DATA_DIRS = "${asahi-audio}/share";
     })
   ]);
 }

--- a/apple-silicon-support/packages/asahi-audio/default.nix
+++ b/apple-silicon-support/packages/asahi-audio/default.nix
@@ -7,13 +7,13 @@ stdenv.mkDerivation rec {
   pname = "asahi-audio";
   # tracking: https://src.fedoraproject.org/rpms/asahi-audio
   # note: ensure that the providedConfigFiles list below is current!
-  version = "1.6";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "AsahiLinux";
     repo = "asahi-audio";
     rev = "v${version}";
-    hash = "sha256-NxTQD742U2FUZNmw7RHuOruMuTRLtAh1HDlMV9EzQkg=";
+    hash = "sha256-5YBQibt/dfJb9/TzF6rczeQE3ySm0SeewhZrgublu2E=";
   };
 
   preBuild = ''
@@ -42,9 +42,7 @@ stdenv.mkDerivation rec {
   # are modified to point to them.
   passthru.providedConfigFiles = [
     "wireplumber/wireplumber.conf.d/99-asahi.conf"
-    "wireplumber/policy.lua.d/85-asahi-policy.lua"
-    "wireplumber/main.lua.d/85-asahi.lua"
-    "wireplumber/scripts/policy-asahi.lua"
+    "wireplumber/scripts/device/asahi-limit-volume.lua"
     "pipewire/pipewire.conf.d/99-asahi.conf"
     "pipewire/pipewire-pulse.conf.d/99-asahi.conf"
   ];

--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714076141,
-        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
+        "lastModified": 1715266358,
+        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
+        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
+        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs = {
       # https://hydra.nixos.org/jobset/mobile-nixos/unstable/evals
       # these evals have a cross-compiled stdenv available
-      url = "github:nixos/nixpkgs/7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856";
+      url = "github:nixos/nixpkgs/f1010e0469db743d14519a1efd37e23f8513d714";
     };
 
     rust-overlay = {


### PR DESCRIPTION
This PR contains the necessary changes needed to upgrade asahi-audio to the 2.x series. In particular, we:

- upgrade `nixpkgs` to latest (one containing Wireplumber 0.5.2)
- bump `asahi-audio` to 2.2
- remove the Wireplumber downgrade
- assert a minimum Wireplumber version needed for use
- make changes needed to have the sound module work with the 0.5.x Wireplumber series

Supersedes #183 .