### PR TITLE
mesa: fix cross compiling

### DIFF
--- a/apple-silicon-support/modules/mesa/default.nix
+++ b/apple-silicon-support/modules/mesa/default.nix
@@ -37,7 +37,8 @@
       # (and in a way compatible with pure evaluation)
       nixpkgs.overlays = [
         (final: prev: {
-          mesa = final.mesa-asahi-edge;
+          # prevent cross-built Mesas that might be evaluated using this config (e.g. Steam emulation via box64) from using the special Asahi Mesa
+          mesa = if prev.targetPlatform.isAarch64 then final.mesa-asahi-edge else prev.mesa;
         })
       ];
     })


### PR DESCRIPTION
This PR prevents weird behavior when cross compiling to other architectures and mesa is wanted.