### PR TITLE
Update nixpkgs to ad57eef

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1716948383,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs = {
       # https://hydra.nixos.org/jobset/mobile-nixos/unstable/evals
       # these evals have a cross-compiled stdenv available
-      url = "github:nixos/nixpkgs/3eaeaeb6b1e08a016380c279f8846e0bd8808916";
+      url = "github:nixos/nixpkgs/ad57eef4ef0659193044870c731987a6df5cf56b";
     };
 
     rust-overlay = {


### PR DESCRIPTION
Corresponds to https://hydra.nixos.org/eval/1806668
Includes gnome 46.2

```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3eaeaeb6b1e08a016380c279f8846e0bd8808916' (2024-05-21)
  → 'github:nixos/nixpkgs/ad57eef4ef0659193044870c731987a6df5cf56b' (2024-05-29)
```