### PR TITLE
Point to "drm_sched_can_queue" workaround

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -86,7 +86,7 @@ let
     (linuxKernel.manualConfig rec {
       inherit stdenv lib;
 
-      version = "6.9.5-asahi";
+      version = "6.9.9-asahi";
       modDirVersion = version;
       extraMeta.branch = "6.9";
 
@@ -94,8 +94,8 @@ let
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.9.5-1";
-        hash = "sha256-+szDagWsNlnUO/TdE14hGunZAun+oXRiqb9VLYAQnwY=";
+        rev = "fd34a0c8a30d41bfea10829d1f9193f6c9150dc1";
+        hash = "sha256-vQTzs5oT5daARTnv0qLcQXO/hCe8sMALJbYTr6iFCPE=";
       };
 
       kernelPatches = [


### PR DESCRIPTION
As discussed below, this changes the kernel reference to point to a workaround commit for the recent GPU related crashes made by @asahilina. Currently testing myself but feel free to merge when you believe it is sufficiently tested.

https://github.com/AsahiLinux/linux/commit/fd34a0c8a30d41bfea10829d1f9193f6c9150dc1
https://github.com/AsahiLinux/linux/issues/309
https://github.com/tpwrules/nixos-apple-silicon/issues/218