### PR TITLE
mesa: Upstream removed lib.platforms.mesaPlatforms

### DIFF
--- a/apple-silicon-support/packages/mesa-asahi-edge/vendor/default.nix
+++ b/apple-silicon-support/packages/mesa-asahi-edge/vendor/default.nix
@@ -536,7 +536,11 @@ self = stdenv.mkDerivation {
     homepage = "https://www.mesa3d.org/";
     changelog = "https://www.mesa3d.org/relnotes/${version}.html";
     license = with lib.licenses; [ mit ]; # X11 variant, in most files
-    platforms = lib.platforms.mesaPlatforms;
+    platforms = [
+      "i686-linux" "x86_64-linux" "x86_64-darwin" "armv5tel-linux"
+      "armv6l-linux" "armv7l-linux" "armv7a-linux" "aarch64-linux"
+      "powerpc64-linux" "powerpc64le-linux" "aarch64-darwin" "riscv64-linux"
+    ];
     badPlatforms = []; # Load bearing for libGL meta on Darwin.
     maintainers = with lib.maintainers; [ primeos vcunat ]; # Help is welcome :)
   };


### PR DESCRIPTION
This fixes the build with current nixos-unstable. 

See https://github.com/NixOS/nixpkgs/pull/338337