### PR TITLE
Rename `system.replaceRuntimeDependencies` -> `system.replaceDependencies.replacements`

### DIFF
--- a/apple-silicon-support/modules/mesa/default.nix
+++ b/apple-silicon-support/modules/mesa/default.nix
@@ -30,7 +30,7 @@
     (lib.mkIf (isMode "replace") {
       # replace the Mesa linked into system packages with the Asahi version
       # without rebuilding them to avoid rebuilding the world.
-      system.replaceRuntimeDependencies = [
+      system.replaceDependencies.replacements = [
         { original = pkgs.mesa;
           replacement = config.hardware.asahi.pkgs.mesa-asahi-edge;
         }


### PR DESCRIPTION
 `system.replaceRuntimeDependencies` has been renamed in NixOS to `system.replaceDependencies.replacements`.
 This PR fixes that to stop warnings when rebuilding the system.