### PR TITLE
bump kernel and add a new option support fan control

### DIFF
--- a/apple-silicon-support/modules/kernel/default.nix
+++ b/apple-silicon-support/modules/kernel/default.nix
@@ -54,6 +54,10 @@
       "hid_generic"
     ];
 
+    boot.extraModprobeConfig = lib.mkIf config.hardware.asahi.enableFanControl ''
+      options macsmc_hwmon melt_my_mac=1
+    '';
+
     boot.kernelParams = [
       "earlycon"
       "console=ttySAC0,115200n8"
@@ -102,6 +106,14 @@
     default = false;
     description = ''
       Build the Asahi Linux kernel with Rust support.
+    '';
+  };
+
+  options.hardware.asahi.enableFanControl = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Enable hwmon fan control on Apple hardware.
     '';
   };
 }

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -86,7 +86,7 @@ let
     (linuxKernel.manualConfig rec {
       inherit stdenv lib;
 
-      version = "6.10.6-asahi";
+      version = "6.10.9-asahi";
       modDirVersion = version;
       extraMeta.branch = "6.10";
 
@@ -94,8 +94,8 @@ let
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.10.6-1";
-        hash = "sha256-qm+0YYHehR2GP/MNAnTSPCBhb1vpnR50bbpfap74BRc=";
+        rev = "asahi-6.10.9-3";
+        hash = "sha256-NdbGfQmcPb+DDa7CMd2NgZbaYXYjbKl8R4uAJ+lAncs=";
       };
 
       kernelPatches = [


### PR DESCRIPTION
- **linux-asahi: asahi-6.10.6-1 -> asahi-6.10.9.3**
- **modules/kernel: add option to enable hwmon fan control**

Tested this on my mac studio m1, being able to slow down the fan makes a huge noise difference.
