### PR TITLE
chromium: disable decommit-pooled-pages as workaround to SIGTRAP

### DIFF
--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -6,4 +6,10 @@ final: prev: {
   mesa-asahi-edge = final.callPackage ./mesa-asahi-edge { };
   alsa-ucm-conf-asahi = final.callPackage ./alsa-ucm-conf-asahi { inherit (prev) alsa-ucm-conf; };
   asahi-audio = final.callPackage ./asahi-audio { };
+
+  # chromium/v8 enabled 'decommit-pooled-pages' in v131, breaking chromium on
+  # systems with 16k pages
+  chromium = prev.chromium.override {
+    commandLineArgs = "--js-flags=--no-decommit-pooled-pages";
+  };
 }


### PR DESCRIPTION
Workaround for this bug on chromium 131+: https://issues.chromium.org/issues/378017037
Hopefully this is not needed for long.