### PR TITLE
Update Pulseaudio Option 

### DIFF
--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -26,7 +26,7 @@
   in lib.mkIf (cfg.setupAsahiSound && cfg.enable) (lib.mkMerge [
     {
       # can't be used by Asahi sound infrastructure
-      hardware.pulseaudio.enable = false;
+      services.pulseaudio.enable = false;
       # enable pipewire to run real-time and avoid audible glitches
       security.rtkit.enable = true;
       # set up pipewire with the supported capabilities (instead of pulseaudio)


### PR DESCRIPTION
Rebuilding yielded the non-fatal warning:
```
evaluation warning: The option `hardware.pulseaudio' defined in `/nix/store/s0l0z3zlkzb4fxzlv26g2nhqbdgkl250-source/apple-silicon-support/modules/sound' has been renamed to `services.pulseaudio'.
```
Changed config hardware.pulseaudio to services.pulseaudio.

This change silenced the warning on my M1 MacBook Air. [My config](https://github.com/azaleacolburn/flake).

~~Unfortunately, I couldn't find any documentation on this change, and [the pulse audio nixos documentation](https://nixos.wiki/wiki/PulseAudio) still lists it as `hardware.pulseaudio`, so I understand if this PR gets closed. Although, perhaps that's a separate config and I'm confusing the two.~~

EDIT: [Updated Documentation](https://wiki.nixos.org/wiki/PulseAudio) which explains that `services.pulseaudio` is the replacement for `hardware.pulseaudio` on nix-unstable (which nixos-apple-silicon uses).