### PR TITLE
alsa-ucm-conf-asahi: do not derive from alsa-ucm-conf

### DIFF
--- a/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
+++ b/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
@@ -1,19 +1,21 @@
-{ lib
+{ stdenv
 , fetchFromGitHub
-, alsa-ucm-conf }:
+}:
 
-(alsa-ucm-conf.overrideAttrs (oldAttrs: rec {
+stdenv.mkDerivation rec {
+  name = "alsa-ucm-conf-asahi";
   version = "5";
 
-  src_asahi = fetchFromGitHub {
+  src = fetchFromGitHub {
     # tracking: https://src.fedoraproject.org/rpms/alsa-ucm-asahi
     owner = "AsahiLinux";
     repo = "alsa-ucm-conf-asahi";
     rev = "v${version}";
     hash = "sha256-daUNz5oUrPfSMO0Tqq/WbtiLHMOtPeQQlI+juGrhTxw=";
   };
-  
-  postInstall = oldAttrs.postInstall or "" + ''
-    cp -r ${src_asahi}/ucm2 $out/share/alsa
+
+  postInstall = ''
+    mkdir -p $out/share/alsa
+    cp -r ${src}/ucm2 $out/share/alsa
   '';
-}))
+}

--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -4,6 +4,6 @@ final: prev: {
   uboot-asahi = final.callPackage ./uboot-asahi { };
   asahi-fwextract = final.callPackage ./asahi-fwextract { };
   mesa-asahi-edge = final.callPackage ./mesa-asahi-edge { };
-  alsa-ucm-conf-asahi = final.callPackage ./alsa-ucm-conf-asahi { inherit (prev) alsa-ucm-conf; };
+  alsa-ucm-conf-asahi = final.callPackage ./alsa-ucm-conf-asahi { };
   asahi-audio = final.callPackage ./asahi-audio { };
 }


### PR DESCRIPTION
We were replacing the version in alsa-ucm-conf-asahi, but alsa-ucm-conf uses `finalAttrs.version` in the source url. So it was using an unrelated version to fetch a source that does not exist. it looksl ike we're only depending on the asahi sources anyways, so i got rid of the `overrideAttrs`.

Fixes #267