### PR TITLE
Remove serial console commandline

### DIFF
--- a/apple-silicon-support/modules/kernel/default.nix
+++ b/apple-silicon-support/modules/kernel/default.nix
@@ -56,7 +56,6 @@
 
     boot.kernelParams = [
       "earlycon"
-      "console=ttySAC0,115200n8"
       "console=tty0"
       "boot.shell_on_fail"
       # Apple's SSDs are slow (~dozens of ms) at processing flush requests which


### PR DESCRIPTION
**What?**
This PR removes the serial console parameter from the kernel commandline

**Why?**
1. This causes plymouth to break. I don't know why it is so, but it is so. This PR would fix issue #257 (which I was also struggling with)
2. It's a little unnecessary. It's not core to getting NixOS to boot and work well (which I assume is the goal of this repo), and if a user wants the serial functionality, they can always add it back in their own NixOS configuration (much easier to add after the fact than trying to apply a patch/overlay something onto this repo to remove the kernel parameter without forking)