### PR TITLE
update asahi-audio, alsa-ucm-conf-asahi, and add triforce-lv2 to sound module for mic support

### DIFF
--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -22,7 +22,6 @@
     lsp-plugins-is-safe = (pkgs.lib.versionAtLeast lsp-plugins.version "1.2.14");
 
     lv2Packages = with pkgs; [ lsp-plugins bankstown-lv2 triforce-lv2 ];
-    lv2Path = lib.makeSearchPath "lib/lv2" ls2Packages;
   in lib.mkIf (cfg.setupAsahiSound && cfg.enable) (lib.mkMerge [
     {
       # can't be used by Asahi sound infrastructure

--- a/apple-silicon-support/modules/sound/default.nix
+++ b/apple-silicon-support/modules/sound/default.nix
@@ -21,7 +21,8 @@
 
     lsp-plugins-is-safe = (pkgs.lib.versionAtLeast lsp-plugins.version "1.2.14");
 
-    lv2Path = lib.makeSearchPath "lib/lv2" [ lsp-plugins pkgs.bankstown-lv2 ];
+    lv2Packages = with pkgs; [ lsp-plugins bankstown-lv2 triforce-lv2 ];
+    lv2Path = lib.makeSearchPath "lib/lv2" ls2Packages;
   in lib.mkIf (cfg.setupAsahiSound && cfg.enable) (lib.mkMerge [
     {
       # can't be used by Asahi sound infrastructure
@@ -36,13 +37,13 @@
         pulse.enable = true;
 
         configPackages = [ asahi-audio ];
-        extraLv2Packages = [ lsp-plugins pkgs.bankstown-lv2 ];
+        extraLv2Packages = lv2Packages;
 
         wireplumber = {
           enable = true;
 
           configPackages = [ asahi-audio ];
-          extraLv2Packages = [ lsp-plugins pkgs.bankstown-lv2 ];
+          extraLv2Packages = lv2Packages;
         };
       };
 

--- a/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
+++ b/apple-silicon-support/packages/alsa-ucm-conf-asahi/default.nix
@@ -4,14 +4,14 @@
 }:
 
 (alsa-ucm-conf.overrideAttrs (oldAttrs: let
-  versionAsahi = "5";
+  versionAsahi = "8";
 
   srcAsahi = fetchFromGitHub {
     # tracking: https://src.fedoraproject.org/rpms/alsa-ucm-asahi
     owner = "AsahiLinux";
     repo = "alsa-ucm-conf-asahi";
     rev = "v${versionAsahi}";
-    hash = "sha256-daUNz5oUrPfSMO0Tqq/WbtiLHMOtPeQQlI+juGrhTxw=";
+    hash = "sha256-FPrAzscc1ICSCQSqULaGLqG4UCq8GZU9XLV7TUSBBRM=";
   };
 in {
   name = "${oldAttrs.pname}-${oldAttrs.version}-asahi-${versionAsahi}";

--- a/apple-silicon-support/packages/asahi-audio/default.nix
+++ b/apple-silicon-support/packages/asahi-audio/default.nix
@@ -9,13 +9,13 @@
 stdenv.mkDerivation rec {
   pname = "asahi-audio";
   # tracking: https://src.fedoraproject.org/rpms/asahi-audio
-  version = "2.5";
+  version = "3.3";
 
   src = fetchFromGitHub {
     owner = "AsahiLinux";
     repo = "asahi-audio";
     rev = "v${version}";
-    hash = "sha256-u+Ef2vA/EQ3b5wsCNPOGEPUk/Vah0mS71gDVhCLBq+g=";
+    hash = "sha256-p0M1pPxov+wSLT2F4G6y5NZpCXzbjZkzle+75zQ4xxU=";
   };
 
   preBuild = ''

--- a/apple-silicon-support/packages/asahi-audio/default.nix
+++ b/apple-silicon-support/packages/asahi-audio/default.nix
@@ -1,6 +1,9 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, lsp-plugins
+, bankstown-lv2
+, triforce-lv2
 }:
 
 stdenv.mkDerivation rec {
@@ -34,4 +37,10 @@ stdenv.mkDerivation rec {
     # no need to link the asahi-audio dir globally
     mv $out/share/asahi-audio $out
   '';
+
+  passthru.requiredLv2Packages = [
+    lsp-plugins
+    bankstown-lv2
+    triforce-lv2
+  ];
 }


### PR DESCRIPTION
## Summary

These are changes manually copied over from an `edge` branch on a fork of this repo I'm playing around with. As per today's announcement, these audio updates have landed in the next Asahi Fedora Remix version and are relevant for `asahi-6.13.7-4` onwards.

> [!WARNING]
> This will only work if the Kernel is updated to track at least `6.13.7-4`!
> `-4` specifically disables flags that block out mic support added via `aop-audio`. This isn't in this PR to keep this PR focused on what it specifically updates (audio/mic updates)

Depends on https://github.com/tpwrules/nixos-apple-silicon/pull/289 to bump nixpkgs to include triforce-lv2.

## Set of changes

- Update asahi-audio to 3.1 (tracking)
- Add missing `passthru.requiredLv2Packages` to `asahi-audio` since it'll help with the sound module in the future
- Update alsa-ucm-conf-asahi to v7 (tracking)
- Add new `triforce-lv2` package to overlay
- Update sound module with new `triforce-lv2` lv2 package