### PR TITLE
flake: expose linux-asahi-with-rust

### DIFF
--- a/apple-silicon-support/packages/overlay.nix
+++ b/apple-silicon-support/packages/overlay.nix
@@ -1,5 +1,6 @@
 final: prev: {
   linux-asahi = final.callPackage ./linux-asahi { };
+  linux-asahi-with-rust = final.callPackage ./linux-asahi { withRust = true; };
   m1n1 = final.callPackage ./m1n1 { };
   uboot-asahi = final.callPackage ./uboot-asahi { };
   asahi-fwextract = final.callPackage ./asahi-fwextract { };

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
               ];
             };
           in {
-            inherit (pkgs) m1n1 uboot-asahi linux-asahi asahi-fwextract mesa-asahi-edge;
+            inherit (pkgs) m1n1 uboot-asahi linux-asahi linux-asahi-with-rust asahi-fwextract mesa-asahi-edge;
             inherit (pkgs) asahi-audio;
 
             installer-bootstrap =


### PR DESCRIPTION
This makes it easier to build a standalone kernel with rust support enabled, by exposing it as an output.