### PR TITLE
use nixpkgs rust cross toolchain for m1n1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,24 +34,7 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1686795910,
-        "narHash": "sha256-jDa40qRZ0GRQtP9EMZdf+uCbvzuLnJglTUI2JoHfWDc=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "5c2b97c0a9bc5217fc3dfb1555aae0fb756d99f9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,6 @@
       url = "github:nixos/nixpkgs/nixos-unstable";
     };
 
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      flake = false;
-    };
-
     flake-compat.url = "github:nix-community/flake-compat";
   };
 
@@ -38,7 +33,6 @@
               crossSystem.system = "aarch64-linux";
               localSystem.system = system;
               overlays = [
-                (import inputs.rust-overlay)
                 self.overlays.default
               ];
             };


### PR DESCRIPTION
Since some time now, nixpkgs has the "fastCross" path for rebuilding only the rust std/core libraries for an additional target and create a wrapper pointing to it as a sysroot. So we can make use of this infrastructure to very quickly (~1min on M1 Pro) build a rustc for the appropriate target.