### PR TITLE
linux-asahi: 6.13.5-4-asahi -> 6.14.2-2-asahi

### DIFF
--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -86,16 +86,16 @@ let
     (linuxKernel.manualConfig rec {
       inherit stdenv lib;
 
-      version = "6.13.8-asahi";
+      version = "6.14.1-asahi";
       modDirVersion = version;
-      extraMeta.branch = "6.13";
+      extraMeta.branch = "6.14";
 
       src = fetchFromGitHub {
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.13.8-1";
-        hash = "sha256-A9xcszHluBm3ehEv/yOhWzbM8bXRa7SHVrIwLp7ISi8=";
+        rev = "asahi-6.14.1-2";
+        hash = "sha256-nSKLePzFawbvaBA6BBTzNHXf9fwb56JHGLugyrSbYKY=";
       };
 
       kernelPatches = [

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -94,8 +94,8 @@ let
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.14.1-2";
-        hash = "sha256-nSKLePzFawbvaBA6BBTzNHXf9fwb56JHGLugyrSbYKY=";
+        rev = "asahi-6.14.1-3";
+        hash = "sha256-aaQaLn/rgKqY1JZNYDxzAi9sZyzaPHgG0ck/SxGeEOo=";
       };
 
       kernelPatches = [

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -86,7 +86,7 @@ let
     (linuxKernel.manualConfig rec {
       inherit stdenv lib;
 
-      version = "6.13.5-asahi";
+      version = "6.13.8-asahi";
       modDirVersion = version;
       extraMeta.branch = "6.13";
 
@@ -94,8 +94,8 @@ let
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.13.5-4";
-        hash = "sha256-/IOYOLLR9XOdCPcYN3txtEzvoY2HZQ7MpgOdNACwfJc=";
+        rev = "asahi-6.13.8-1";
+        hash = "sha256-A9xcszHluBm3ehEv/yOhWzbM8bXRa7SHVrIwLp7ISi8=";
       };
 
       kernelPatches = [

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -86,7 +86,7 @@ let
     (linuxKernel.manualConfig rec {
       inherit stdenv lib;
 
-      version = "6.14.1-asahi";
+      version = "6.14.2-asahi";
       modDirVersion = version;
       extraMeta.branch = "6.14";
 
@@ -94,8 +94,8 @@ let
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.14.1-3";
-        hash = "sha256-aaQaLn/rgKqY1JZNYDxzAi9sZyzaPHgG0ck/SxGeEOo=";
+        rev = "asahi-6.14.2-1";
+        hash = "sha256-2o5laygnZFWOBz8dlaQvoUc9XNHCzZlWUpqtE4WSJ4I=";
       };
 
       kernelPatches = [

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -94,8 +94,8 @@ let
         # tracking: https://github.com/AsahiLinux/linux/tree/asahi-wip (w/ fedora verification)
         owner = "AsahiLinux";
         repo = "linux";
-        rev = "asahi-6.14.2-1";
-        hash = "sha256-2o5laygnZFWOBz8dlaQvoUc9XNHCzZlWUpqtE4WSJ4I=";
+        rev = "asahi-6.14.2-2";
+        hash = "sha256-Zqrzj+8rF0aDqIpu8lgB2juEfJZEhosj1icyI2/JiwE=";
       };
 
       kernelPatches = [

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -1,7 +1,5 @@
 { lib
-, pkgs
 , callPackage
-, writeShellScriptBin
 , writeText
 , linuxPackagesFor
 , withRust ? false

--- a/apple-silicon-support/packages/linux-asahi/default.nix
+++ b/apple-silicon-support/packages/linux-asahi/default.nix
@@ -73,10 +73,6 @@ let
         configList = (parseConfig origConfigText) ++ extraConfig;
       in builtins.listToAttrs (map makePair (lib.lists.reverseList configList));
 
-      # used to (ostensibly) keep compatibility for those running stable versions of nixos
-      rustOlder = version: withRust && (lib.versionOlder rustc.version version);
-      bindgenOlder = version: withRust && (lib.versionOlder rust-bindgen.unwrapped.version version);
-
       # used to fix issues when nixpkgs gets ahead of the kernel
       rustAtLeast = version: withRust && (lib.versionAtLeast rustc.version version);
       bindgenAtLeast = version: withRust && (lib.versionAtLeast rust-bindgen.unwrapped.version version);


### PR DESCRIPTION
This bumps the `linux-asahi` package to 6.14.2-1.

I tested this alongside #284, #287, #289 and #290.